### PR TITLE
Get data rep from a set of names

### DIFF
--- a/src/data/DataSet.cpp
+++ b/src/data/DataSet.cpp
@@ -1,0 +1,28 @@
+#include <DataSet.h>
+#include <DataRepresentation.h>
+#include <DataExceptions.h>
+#include <string>
+#include <vector>
+#include <algorithm>
+typedef std::vector<std::string> StringVec;
+
+DataRepresentation 
+DataSet::MakeDataRep(const StringVec observableNames_) const{
+    std::vector<size_t> indicies;
+    indicies.reserve(observableNames_.size());
+    
+    StringVec availableNames = GetObservableNames();
+    for(size_t i = 0; i < observableNames_.size(); i++){
+        StringVec::iterator pos = std::find(availableNames.begin(),
+                                            availableNames.end(),
+                                            observableNames_.at(i)
+                                            );
+        if(pos == availableNames.end())
+            throw RepresentationError("DataSet::Asked for representation containing non-existent variable");
+        else
+            indicies.push_back(pos - availableNames.begin());
+    }
+    return DataRepresentation(indicies);
+}
+
+

--- a/src/data/DataSet.h
+++ b/src/data/DataSet.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <string>
 
+class DataRepresentation;
 class EventData;
 class DataSet{
  public:
@@ -18,6 +19,8 @@ class DataSet{
     virtual unsigned GetNObservables() const {return fNObservables;}
 
     virtual std::vector<std::string> GetObservableNames() const = 0;
+    DataRepresentation MakeDataRep(const std::vector<std::string> observableNames_) const;
+
  protected:
     unsigned fNObservables;
     unsigned fNEntries;

--- a/test/unit/data/DataRepresentationTest.cpp
+++ b/test/unit/data/DataRepresentationTest.cpp
@@ -1,5 +1,6 @@
 #include <catch.hpp>
 #include <DataRepresentation.h>
+#include <OXSXDataSet.h>
 
 TEST_CASE("Build from one index"){
     DataRepresentation drep(19);
@@ -58,3 +59,34 @@ TEST_CASE("Looking for the relative indices of 2d rep in 4d rep"){
     REQUIRE(relativeIndices.at(1) == 0);
     
 }
+
+TEST_CASE("Creating a DataRepresentation from a DataSet by observable name"){
+    // create a dummy dataset with some observables in it
+    std::vector<std::string> observables;
+    observables.push_back("obs_1");
+    observables.push_back("obs_2");
+    observables.push_back("obs_3");
+    observables.push_back("obs_4");
+
+    OXSXDataSet dataSet;
+    dataSet.SetObservableNames(observables);
+    
+    // now ask the data set for the representation corresponding to obs_4, obs_3, obs_2
+    std::vector<std::string> requestedObs;
+    requestedObs.push_back("obs_4");
+    requestedObs.push_back("obs_3");
+    requestedObs.push_back("obs_2");
+
+    DataRepresentation generatedRep = dataSet.MakeDataRep(requestedObs);
+
+    //check it did it right
+    REQUIRE(generatedRep.GetLength() == requestedObs.size());
+    for(size_t i = 0; i < requestedObs.size(); i++){
+        size_t generatedIndex = generatedRep.GetIndices().at(i);
+        std::string generatedName = observables.at(generatedIndex);
+        REQUIRE(generatedName == requestedObs.at(i));
+        
+    }
+}
+
+                


### PR DESCRIPTION
* Users should not have to know the position of the observables they want in the data set
* only the data set knows where they are!
* dont want something sitting above for a conversion
* so just ask the data set for the representation you want e.g.

```
DataRepresentation rep = dataSet.MakeDataRep({"energy", "radius", "time"});
pdf.SetDataRep(rep);
```

