### PR TITLE
Pdf Filler with no cuts & Cut Examples

### DIFF
--- a/examples/Cuts.cpp
+++ b/examples/Cuts.cpp
@@ -6,9 +6,52 @@ The CutCollection object is used to FillPdfs or generate data sets, only taking 
 */
 #include <BoxCut.h>
 #include <BoolCut.h>
+#include <LineCut.h>
+#include <CutCollection.h>
 #include <EventData.h>
+#include <iostream>
 
 int main(){
-    // cut if first observable is bigger than zero
-    BoxCut
+    // cut if first observable is bigger than two i.e. a lower limit
+    LineCut lineCut(0, 2, "lower");
+    
+    // cut if second observable is between 5 and 10
+    BoxCut boxCut(1, 5, 10);
+
+    // cut if the third value is 1 exactly
+    BoolCut boolCut(2, 1);
+
+    // Combine the three cuts
+    CutCollection combinedCuts;
+    combinedCuts.AddCut(lineCut);
+    combinedCuts.AddCut(boxCut);
+    combinedCuts.AddCut(boolCut);
+
+    // Create a fake event to test
+    std::vector<double> observations;
+    observations.push_back(1);
+    observations.push_back(6);
+    observations.push_back(1);
+
+    EventData fakeEvent(observations);
+
+    // test it
+    std::cout << "Event passes line cut " 
+              << lineCut.PassesCut(fakeEvent)
+              << std::endl;
+
+    std::cout << "Event passes box cut " 
+              << boxCut.PassesCut(fakeEvent)
+              << std::endl;
+
+    std::cout << "Event passes bool cut " 
+              << boolCut.PassesCut(fakeEvent)
+              << std::endl;
+
+    std::cout << "Event passes all cuts " 
+              << combinedCuts.PassesCuts(fakeEvent)
+              << std::endl;
+
+    return 0;
+    
 }

--- a/src/pdf/PdfFiller.h
+++ b/src/pdf/PdfFiller.h
@@ -1,13 +1,14 @@
 #ifndef __OXSX_PDF_FILLER__
 #define __OXSX_PDF_FILLER__
-class CutCollection;
+#include <CutCollection.h>
 class DataSet;
 class BinnedPdf;
 
 class PdfFiller{
  public:
   // default is to take all the events
-  static void FillPdf(BinnedPdf&, const DataSet&, const CutCollection& cuts_, int nEv_ = -1);
+  static void FillPdf(BinnedPdf&, const DataSet&, 
+                      const CutCollection& cuts_ = CutCollection(), int nEv_ = -1);
 };
 
 #endif

--- a/test/unit/cut/CutTest.cpp
+++ b/test/unit/cut/CutTest.cpp
@@ -1,5 +1,8 @@
 #include <catch.hpp>
 #include <BoxCut.h>
+#include <BoolCut.h>
+#include <LineCut.h>
+#include <CutCollection.h>
 
 TEST_CASE("1D Box cut"){
     BoxCut cut(0, 1 , 10);
@@ -30,4 +33,35 @@ TEST_CASE("1D Box cut"){
         EventData ev(std::vector<double>(1, 10));
         REQUIRE(cut.PassesCut(ev) == false);
     }
+}
+
+TEST_CASE("Several Cuts on MultiD data"){
+    //  First val must be more than 2
+    LineCut lineCut(0, 2, "lower");
+
+    // cut if second observable is between 5 and 10
+    BoxCut boxCut(1, 5, 10);
+
+    // cut if the third value is 1 exactly
+    BoolCut boolCut(2, 1);
+
+    // Combine the three cuts
+    CutCollection combinedCuts;
+    combinedCuts.AddCut(lineCut);
+    combinedCuts.AddCut(boxCut);
+    combinedCuts.AddCut(boolCut);
+
+    // Create a fake event to test
+    std::vector<double> observations;
+    observations.push_back(1);
+    observations.push_back(6);
+    observations.push_back(1);
+
+    EventData fakeEvent(observations);
+
+    // Check vals
+    REQUIRE(lineCut.PassesCut(fakeEvent) == false);
+    REQUIRE(boxCut.PassesCut(fakeEvent)  == true);
+    REQUIRE(boolCut.PassesCut(fakeEvent) == true);
+    REQUIRE(combinedCuts.PassesCuts(fakeEvent) == false);
 }


### PR DESCRIPTION
* PdfFiller should fill pdfs even if the user doesnt want to apply any cuts, so update the default value for 
`PdfFiller::FillPdf()`

* add examples to show cuts

* add cuts test 