### PR TITLE
Src Sconscript fix

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -4,7 +4,7 @@ import os
 Import('env')
 
 # Compile all .cpp files in source tree
-source_dirs  = [x[0] for x in os.walk(".")]
+source_dirs  = [x[0] for x in os.walk(Dir("#/src").abspath)]
 source_files = []
 for x in source_dirs:
     source_files += Glob(os.path.join(x,"*.cpp"))


### PR DESCRIPTION
* `src` is built into variant dir `build/`
* `os.path.walk` doesn't know that, so it looks in the `build/` directory
* This works fine unless you add a new directory in src - it's not present in build so gets ignored by scons

Soln:
* use scons to refer to `src` relative to the top level SConstruct