### PR TITLE
Fix variant dir problem with scons

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -8,8 +8,9 @@ env.Append(CPPPATH = "#/include")
 Export('env')
 
 # now copy the headers to include and build the library
+env.Replace(SRC_VARIANT_DIR =  "build")
 lib = env.SConscript("src/SConscript",
-                     variant_dir="build", duplicate = 0)
+                     variant_dir = env["SRC_VARIANT_DIR"], duplicate = 0)
 Export('lib')
 
 # now build the tests

--- a/src/SConscript
+++ b/src/SConscript
@@ -4,7 +4,11 @@ import os
 Import('env')
 
 # Compile all .cpp files in source tree
-source_dirs  = [x[0] for x in os.walk(Dir("#/src").abspath)]
+source_dirs  = [x[0] for x in os.walk("../src")]
+print source_dirs
+# replace it with variant_dir locs, scons doesn't know these exist yet
+source_dirs = [x.replace("src", env["SRC_VARIANT_DIR"]) for x in source_dirs]
+
 source_files = []
 for x in source_dirs:
     source_files += Glob(os.path.join(x,"*.cpp"))

--- a/src/SConscript
+++ b/src/SConscript
@@ -4,8 +4,8 @@ import os
 Import('env')
 
 # Compile all .cpp files in source tree
-source_dirs  = [x[0] for x in os.walk("../src")]
-print source_dirs
+source_dirs  = [x[0] for x in os.walk(Dir("#/src").abspath)]
+
 # replace it with variant_dir locs, scons doesn't know these exist yet
 source_dirs = [x.replace("src", env["SRC_VARIANT_DIR"]) for x in source_dirs]
 


### PR DESCRIPTION
* Python `os.walk` tries to walk `variant_dir = build`
* scons guarantees that these files _will_ exist, but they don't at the the time of exectution

* help scons along by telling it where the files _will_ be 