### PR TITLE
fix compatible bin bug

### DIFF
--- a/src/systematic/Convolution.cpp
+++ b/src/systematic/Convolution.cpp
@@ -87,6 +87,7 @@ Convolution::CacheCompatibleBins(){
     fCompatibleBins.resize(fPdfMapping.GetNBins());
     // only need to look at one side of the matrix, its symmetric
     for(size_t i = 0; i < fPdfMapping.GetNBins(); i++){
+        fCompatibleBins.at(i).push_back(i); // always true
         for(size_t j = i+1;  j < fPdfMapping.GetNBins(); j++){
             if(BinsCompatible(i , j)){
                 fCompatibleBins.at(i).push_back(j);


### PR DESCRIPTION
thanks @drjeannewilson
* Move to sparse matrix calculation in Convolution class or changes to compatible bin methods introduced a bug
* When compatible bins are calculated (i.e. those with the same indicies in all dimensions except for the ones being smeared) we miss the diagonal elements - i.e. we miss that the bin is compatible with itself

So just add that one to the list