### PR TITLE
Add back in constraints to binnednllh

### DIFF
--- a/src/core/ComponentManager.cpp
+++ b/src/core/ComponentManager.cpp
@@ -1,5 +1,6 @@
 #include <ComponentManager.h>
 #include <Exceptions.h>
+#include <algorithm>
 #include <iostream>
 
 void 
@@ -37,7 +38,7 @@ ComponentManager::GetParameters() const{
     std::vector<double> params;
     for(size_t i = 0; i < fComponents.size(); i++){
         const std::vector<double>& comps = fComponents.at(i) -> GetParameters();
-                params.insert(params.end(), comps.begin(), comps.end());
+        params.insert(params.end(), comps.begin(), comps.end());
     }
     return params;
 }
@@ -51,6 +52,7 @@ ComponentManager::GetParameterNames() const{
     }
     return paramNames;
 }
+
 int
 ComponentManager::GetTotalParameterCount() const{
     return fTotalParamCount;
@@ -62,4 +64,21 @@ ComponentManager::Clear(){
     fComponentCount  = 0;
     fComponents.clear();
     fParamCounts.clear();
+}
+
+double
+ComponentManager::GetParameter(const std::string& paramName_){
+    for(size_t i = 0; i < fComponents.size(); i++){
+        FitComponent* component = fComponents[i];
+        std::vector<std::string> names = component->GetParameterNames();
+
+        std::vector<std::string>::iterator it = std::find(names.begin(), names.end(), 
+                                                          paramName_);
+        if(it != names.end())
+            return component->GetParameters()[it - names.begin()];
+    }
+    throw NotFoundError(Formatter() << "ComponentManager::GetParameter "
+                        << " requested non-existent parameter "
+                        << paramName_
+                        );
 }

--- a/src/core/ComponentManager.cpp
+++ b/src/core/ComponentManager.cpp
@@ -67,7 +67,7 @@ ComponentManager::Clear(){
 }
 
 double
-ComponentManager::GetParameter(const std::string& paramName_){
+ComponentManager::GetParameter(const std::string& paramName_) const{
     for(size_t i = 0; i < fComponents.size(); i++){
         FitComponent* component = fComponents[i];
         std::vector<std::string> names = component->GetParameterNames();

--- a/src/core/ComponentManager.h
+++ b/src/core/ComponentManager.h
@@ -15,7 +15,7 @@ class ComponentManager{
     int                       GetTotalParameterCount() const;
     void                      Clear();
 
-    double GetParameter(const std::string&);
+    double GetParameter(const std::string&) const;
 
  private:
     std::vector<FitComponent*>  fComponents;

--- a/src/core/ComponentManager.h
+++ b/src/core/ComponentManager.h
@@ -14,9 +14,12 @@ class ComponentManager{
     std::vector<double>       GetParameters() const;
     int                       GetTotalParameterCount() const;
     void                      Clear();
+
+    double GetParameter(const std::string&);
+
  private:
-    std::vector<FitComponent*> fComponents;
-    std::vector<int>           fParamCounts;
+    std::vector<FitComponent*>  fComponents;
+    std::vector<int>            fParamCounts;
 
     int fTotalParamCount;
     int fComponentCount;

--- a/src/teststat/BinnedNLLH.cpp
+++ b/src/teststat/BinnedNLLH.cpp
@@ -38,12 +38,9 @@ BinnedNLLH::Evaluate(){
         nLogLH += normalisations.at(i);
             
     // Constraints
-    // FIXME:: Put this back in!
-//     for(size_t i = 0; i < fSystematicConstraints.size(); i++)
-//         nLogLH += fSystematicConstraints.at(i).operator()(fSystematicParams);
-    
-//     for(size_t i = 0; i < fNormalisationConstraints.size(); i++)
-//         nLogLH += fNormalisationConstraints.at(i).operator()(normalisations);
+    for(std::map<std::string, QuadraticConstraint>::iterator it = fConstraints.begin();
+        it != fConstraints.end(); ++it)
+        nLogLH += it->second.Evaluate(fComponentManager.GetParameter(it->first));
 
     return nLogLH;
 }
@@ -65,42 +62,6 @@ BinnedNLLH::SetPdfManager(const BinnedPdfManager& man_){
 void
 BinnedNLLH::SetSystematicManager(const SystematicManager& man_){
     fSystematicManager = man_;
-}
-
-
-void
-BinnedNLLH::SetSystematicConstraint(size_t index_, const QuadraticConstraint& constr_){
-    if(index_ >= fSystematicConstraints.size())
-        throw DimensionError("Tried to set systematic constraint that doesn't exist : logic error");
-    fSystematicConstraints[index_] = constr_;
-}
-
-
-void
-BinnedNLLH::AddNormalisationConstraint(const QuadraticConstraint& constr_){
-    fNormalisationConstraints.push_back(constr_);
-}
-
-void
-BinnedNLLH::SetNormalisationConstraint(size_t index_, const QuadraticConstraint& constr_){
-    if(index_ >= fNormalisationConstraints.size())
-        throw DimensionError("BinnedNNLH::Tried to set systematic constraint that doesn't exist : logic error");
-    fNormalisationConstraints[index_] = constr_;
-}
-
-QuadraticConstraint
-BinnedNLLH::GetNormalisationConstraint(size_t index_) const{
-    if(index_ >= fNormalisationConstraints.size())
-        throw DimensionError("BinnedNLLH::Attempted access on non existent constraint");
-    return fNormalisationConstraints.at(index_);
-}
-
-
-QuadraticConstraint
-BinnedNLLH::GetSystematicConstraint(size_t index_) const{
-    if(index_ >= fSystematicConstraints.size())
-        throw DimensionError("BinnedNLLH::Attempted access on non existent constraint");
-    return fSystematicConstraints.at(index_);
 }
 
 void
@@ -184,8 +145,14 @@ BinnedNLLH::AddCut(const Cut& cut_){
     fCuts.AddCut(cut_);
 }
 
-void BinnedNLLH::SetCuts(const CutCollection& cuts_){
+void 
+BinnedNLLH::SetCuts(const CutCollection& cuts_){
     fCuts = cuts_;
+}
+
+void 
+BinnedNLLH::SetConstraint(const std::string& paramName_, double mean_, double sigma_){
+    fConstraints[paramName_] = QuadraticConstraint(mean_, sigma_);
 }
 
 /////////////////////////////////////////////////////////

--- a/src/teststat/BinnedNLLH.h
+++ b/src/teststat/BinnedNLLH.h
@@ -4,11 +4,12 @@
 #include <BinnedPdfManager.h>
 #include <SystematicManager.h>
 #include <BinnedPdfShrinker.h>
-#include <vector>
-#include <QuadraticConstraint.h>
 #include <ComponentManager.h>
 #include <DataSet.h>
 #include <CutCollection.h>
+#include <QuadraticConstraint.h>
+#include <map>
+#include <vector>
 
 class DataSet;
 class BinnedNLLH : public TestStatistic{
@@ -24,15 +25,8 @@ class BinnedNLLH : public TestStatistic{
     void   AddPdfs(const std::vector<BinnedPdf>&);
     void   AddSystematics(const std::vector<Systematic*>);
 
-    void AddSystematicConstraint(const QuadraticConstraint& constr_);
-    void AddNormalisationConstraint(const QuadraticConstraint& constr_);
-
-    void SetSystematicConstraint(size_t index_, const QuadraticConstraint& constr_);
-    void SetNormalisationConstraint(size_t index_, const QuadraticConstraint& constr_);
-
-    QuadraticConstraint GetSystematicConstraint(size_t index_)    const;
-    QuadraticConstraint GetNormalisationConstraint(size_t index_)  const;
-
+    void   SetConstraint(const std::string& paramName_, double mean_, double sigma_);
+    
     void SetNormalisations(const std::vector<double>& norms_);
     std::vector<double> GetNormalisations() const;
 
@@ -66,10 +60,8 @@ class BinnedNLLH : public TestStatistic{
     BinnedPdfShrinker fPdfShrinker;
     DataSet* fDataSet;
     CutCollection fCuts;
+    std::map<std::string, QuadraticConstraint> fConstraints;
 
-    std::vector<QuadraticConstraint> fSystematicConstraints;
-    std::vector<QuadraticConstraint> fNormalisationConstraints;
-    
     BinnedPdf fDataPdf;
     bool      fCalculatedDataPdf;
     ComponentManager fComponentManager;    

--- a/src/teststat/QuadraticConstraint.h
+++ b/src/teststat/QuadraticConstraint.h
@@ -7,17 +7,16 @@
 
 class QuadraticConstraint{
  public:
- QuadraticConstraint(size_t paramIndex_, double mean_, double width_) : 
-    fMean(mean_), fWidth(width_), fParamIndex(paramIndex_) {}
+ QuadraticConstraint(){}
+ QuadraticConstraint(double mean_, double width_) : 
+    fMean(mean_), fWidth(width_) {}
 
-    double operator()(const std::vector<double>& vals_) const {
-        double val = vals_.at(fParamIndex);
-        return (val - fMean) * (val - fMean) / (2 * fWidth * fWidth);
+    double Evaluate(double val_) const {
+        return (val_ - fMean) * (val_ - fMean) / (2 * fWidth * fWidth);
     }
     
  private:
     double fMean;
     double fWidth;
-    size_t fParamIndex;
 };
 #endif

--- a/test/unit/core/ComponentManagerTest.cpp
+++ b/test/unit/core/ComponentManagerTest.cpp
@@ -25,8 +25,8 @@ TEST_CASE("Stand alone component manager"){
     SECTION("adding two"){
         cmpMan.AddComponent(&pdf1);
         cmpMan.AddComponent(&pdf2);
-        REQUIRE(cmpMan.GetTotalParameterCount() == 100 * 2);
-        
+        REQUIRE(cmpMan.GetTotalParameterCount() == 100 * 2);        
+
         cmpMan.SetParameters(std::vector<double> (100 * 2, 8));
         REQUIRE(pdf1.GetParameters() == std::vector<double>(100, 8));
         REQUIRE(pdf2.GetParameters() == std::vector<double>(100, 8));
@@ -37,5 +37,11 @@ TEST_CASE("Stand alone component manager"){
         REQUIRE(cmpMan.GetTotalParameterCount() == 0);
         REQUIRE(cmpMan.GetParameterNames() == std::vector<std::string>(0));
     }
-    
+    SECTION("getting parameter by name"){
+        cmpMan.AddComponent(&pdf1);
+        REQUIRE(cmpMan.GetParameter("Spectral fit bin 0") == 0);
+        pdf1.SetBinContent(0, 10);
+        REQUIRE(cmpMan.GetParameter("Spectral fit bin 0") == 10);
+        
+    }
 }

--- a/test/unit/teststat/BinnedNLLHTest.cpp
+++ b/test/unit/teststat/BinnedNLLHTest.cpp
@@ -2,8 +2,8 @@
 #include <BinnedNLLH.h>
 #include <Gaussian.h>
 #include <PdfConverter.h>
-#include <iostream>
 #include <OXSXDataSet.h>
+#include <iostream>
 
 TEST_CASE("Binned NLLH, 3 rates no systematics"){
     Gaussian gaus1(1, 10);
@@ -44,5 +44,16 @@ TEST_CASE("Binned NLLH, 3 rates no systematics"){
         
         lh.SetParameters(std::vector<double>(3, 1));
         REQUIRE(lh.Evaluate() == Approx(sumNorm + sumLogProb));
+    }
+
+    SECTION("Correct Probability with constraint"){
+        lh.SetConstraint("Pdf Normalisation 0", 3, 1);
+
+        double sumLogProb = -log(prob1 + prob2 + prob3);
+        double sumNorm    = 3;
+        double constraint = 2;
+
+        lh.SetParameters(std::vector<double>(3, 1));
+        REQUIRE(lh.Evaluate() == Approx(sumNorm + sumLogProb + constraint));
     }
 }


### PR DESCRIPTION
@drjeannewilson

Add back in constraints:
* Component manager now has a `double GetParameter(const std::string&) const` method
* Quadratic constraint now just has a mean and a sigma and returns a value
* BinnedNLLH now has a `SetConstraint(const std::string& paramName_, double mean,_ double sigma_)`
* This stores the constraint in a map, keyed by the parameter name.
* when the likelihood is evaluated we loop over the map, finding the values of each of the parameters and evaluating the constraints

Also added passing unit tests
