### PR TITLE
Component Manager bug fix

### DIFF
--- a/src/core/ComponentManager.cpp
+++ b/src/core/ComponentManager.cpp
@@ -24,12 +24,15 @@ ComponentManager::SetParameters(const std::vector<double>& params_){
     std::vector<double>::const_iterator it = params_.begin();
     fComponents[0] -> SetParameters(std::vector<double>(it, 
                                                         it + fParamCounts.at(0)));
+
+    size_t nUnpacked = fComponents.at(0) -> GetParameterCount();
     for(size_t i = 1; i < fComponents.size(); i++){
-        fComponents[i] -> SetParameters(std::vector<double>(it + fParamCounts.at(i-1),
-                                                            it  + fParamCounts.at(i-1) +
+        fComponents[i] -> SetParameters(std::vector<double>(it + nUnpacked,
+                                                            it  + nUnpacked
                                                             + fParamCounts.at(i)
                                                             )
                                         );
+        nUnpacked += fParamCounts.at(i);
     }
 }
 

--- a/src/core/histogram/PdfAxis.cpp
+++ b/src/core/histogram/PdfAxis.cpp
@@ -70,7 +70,7 @@ PdfAxis::PdfAxis(const std::string& name_, const std::vector<double>& lowEdges_,
 
 size_t 
 PdfAxis::FindBin(double value_) const{
-  size_t insertIndex = std::lower_bound(fBinLowEdges.begin(), fBinLowEdges.end(), value_) - fBinLowEdges.begin();
+  size_t insertIndex = std::lower_bound(fBinHighEdges.begin(), fBinHighEdges.end(), value_) - fBinHighEdges.begin();
     if (insertIndex == fNBins)
         return insertIndex-1;
     return insertIndex;


### PR DESCRIPTION
@drjeannewilson pointed out that ComponentManager was not handing out parameters correctly when you have more than two components in BinnedNLLH (e.g. Pdfs + convolution + scale). 