### PR TITLE
size_t on ubuntu

### DIFF
--- a/src/fitutil/EventSystematicManager.h
+++ b/src/fitutil/EventSystematicManager.h
@@ -1,6 +1,7 @@
 #ifndef __EVENT_SYSTEMATIC_MANAGER__
 #define __EVENT_SYSTEMATIC_MANAGER__
 #include <vector>
+#include <stddef.h>
 
 class EventSystematic;
 class Event;

--- a/src/histogram/HistTools.h
+++ b/src/histogram/HistTools.h
@@ -1,6 +1,9 @@
 #ifndef __OXSX_HIST_TOOLS__
 #define __OXSX_HIST_TOOLS__
 #include <vector>
+#include <stddef.h>
+
+
 class AxisCollection;
 class Histogram;
 


### PR DESCRIPTION
When trying to building on ubuntu (with gcc4.8, however also tested with gcc5) scons complains about the definition of size_t. Adding these two lines stops the complaints and it builds successfully. However i haven't tested it.   