### PR TITLE
Give all `EventDistribution` a name

### DIFF
--- a/src/dist/AnalyticED.cpp
+++ b/src/dist/AnalyticED.cpp
@@ -3,7 +3,8 @@
 #include <EventDistribution.h>
 #include <PDF.h>
 
-AnalyticED::AnalyticED(PDF* f_){
+AnalyticED::AnalyticED(const std::string& name_, PDF* f_){
+    fName = name_;
     fFunction = dynamic_cast<PDF*>(f_->Clone());
     fNorm     = 1;
 }
@@ -13,6 +14,7 @@ AnalyticED::~AnalyticED(){
 }
 
 AnalyticED::AnalyticED(const AnalyticED& other_){
+    fName  = other_.fName;
     fNorm  = other_.fNorm;
     fObservables = other_.fObservables;
     fFunction = dynamic_cast<PDF*>(other_.fFunction->Clone());
@@ -72,6 +74,17 @@ unsigned
 AnalyticED::GetNDims() const{
     return fFunction->GetNDims();
 }
+
+std::string
+AnalyticED::GetName() const{
+    return fName;
+}
+
+void
+AnalyticED::SetName(const std::string& name_){
+    fName = name_;
+}
+
 
 // Fitting this pdf to data means adjusting the underlying function
 void

--- a/src/dist/AnalyticED.h
+++ b/src/dist/AnalyticED.h
@@ -3,11 +3,12 @@
 #include <EventDistribution.h>
 #include <FitComponent.h>
 #include <ObsSet.h>
+#include <string>
 
 class PDF;
 class AnalyticED : public EventDistribution, public FitComponent{
  public:
-    AnalyticED(PDF*); // make a copy
+    AnalyticED(const std::string&, PDF*); // make a copy
     AnalyticED(const AnalyticED& other_); // deep copy
     ~AnalyticED();         // frees fFunction
     EventDistribution* Clone() const;
@@ -23,6 +24,9 @@ class AnalyticED : public EventDistribution, public FitComponent{
     
     unsigned GetNDims() const;
 
+    std::string GetName() const;
+    void SetName(const std::string&);
+
     // FitComponent interface : pass on calls to fFunction, change names
     void MakeFittable();
     std::vector<std::string> GetParameterNames() const;
@@ -35,5 +39,6 @@ class AnalyticED : public EventDistribution, public FitComponent{
     ObsSet        fObservables;
     PDF*          fFunction;
     double        fNorm;
+    std::string   fName;
 };
 #endif

--- a/src/dist/BinnedED.cpp
+++ b/src/dist/BinnedED.cpp
@@ -5,11 +5,13 @@
 #include <iostream>
 
 
-BinnedED::BinnedED(const AxisCollection& axes_){
+BinnedED::BinnedED(const std::string& name_, const AxisCollection& axes_){
+    fName = name_;
     fHistogram.SetAxes(axes_);
 }
 
-BinnedED::BinnedED(const Histogram& histo_){
+BinnedED::BinnedED(const std::string& name_, const Histogram& histo_){
+    fName = name_;
     fHistogram = histo_;
 }
 
@@ -58,6 +60,16 @@ BinnedED::Clone() const{
     return static_cast<EventDistribution*>(new BinnedED(*this));
 }
 
+
+std::string 
+BinnedED::GetName() const{
+    return fName;
+}
+
+void 
+BinnedED::SetName(const std::string& name_){
+    fName = name_;
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // All methods below this line just forward the call to the underlying histogram object //
@@ -189,10 +201,17 @@ BinnedED::Marginalise(const std::vector<size_t>& indices_) const{
     ObsSet newRep = ObsSet(indices_);
     std::vector<size_t> relativeIndices = newRep.GetRelativeIndices(fObservables);
 
+    // create a name for the projection
+    Formatter f;
+    f << fName;
+    for(size_t i = 0; i < indices_.size(); i++)
+        f << "_" << i;
+    f << "_proj";
+
     // Marginalise the histogram
-    BinnedED newPhysDist(fHistogram.Marginalise(relativeIndices));
-    newPhysDist.SetObservables(newRep);
-    return newPhysDist;
+    BinnedED proj(std::string(f), fHistogram.Marginalise(relativeIndices));
+    proj.SetObservables(newRep);
+    return proj;
 }
 
 BinnedED

--- a/src/dist/BinnedED.h
+++ b/src/dist/BinnedED.h
@@ -17,8 +17,8 @@ class Event;
 class BinnedED : public EventDistribution{
  public:
     BinnedED() {}
-    BinnedED(const AxisCollection& axes_);
-    BinnedED(const Histogram& histo_);
+    BinnedED(const std::string& name_, const AxisCollection& axes_);
+    BinnedED(const std::string& name_, const Histogram& histo_);
     EventDistribution*   Clone() const; 
 
     double Probability(const Event&) const;
@@ -67,9 +67,13 @@ class BinnedED : public EventDistribution{
     void Add(const BinnedED& other_, double weight_ = 1);
     void Multiply(const BinnedED& other_);
     void Divide(const BinnedED& other_);
+
+    std::string GetName() const;
+    void SetName(const std::string&);
     
  protected:
-    ObsSet    fObservables;
-    Histogram fHistogram;
+    ObsSet      fObservables;
+    Histogram   fHistogram;
+    std::string fName;    
 };
 #endif

--- a/src/dist/BinnedEDGenerator.h
+++ b/src/dist/BinnedEDGenerator.h
@@ -14,7 +14,7 @@ class BinnedEDGenerator{
     BinnedED PoissonFluctuatedPdf() const;
 
  private:
-    std::vector<BinnedED> fPdfs;
+    std::vector<BinnedED>  fPdfs;
     std::vector<double>    fRates;
     size_t RandomBin(size_t pdfIndex_) const;
 };

--- a/src/dist/CompositeED.cpp
+++ b/src/dist/CompositeED.cpp
@@ -6,14 +6,19 @@
 CompositeED::CompositeED(const EventDistribution* p1_, const EventDistribution* p2_) {
     fDistPtrs.push_back(p1_ -> Clone());
     fDistPtrs.push_back(p2_ -> Clone());  
-
+    fName = p1_->GetName() + "*" + p2_->GetName();
 }
 
 CompositeED::CompositeED(const std::vector<EventDistribution*>& pdfs_){
     // if one of the pdfs is composite itself the copy will happen recursively all the way down
+    std::string name;
     for(size_t i = 0; i < pdfs_.size(); i++){
         fDistPtrs.push_back(pdfs_[i] -> Clone());
+        name += pdfs_[i]->GetName();
+        if(i != pdfs_.size() - 1)
+            name += "*";
     }
+    fName = name;
 }
 CompositeED::~CompositeED() {
     for(size_t i = 0; i < fDistPtrs.size(); i++)
@@ -48,12 +53,10 @@ CompositeED::Clone() const {
     return static_cast<EventDistribution*>(cp);
 }
 
-
 CompositeED
 operator * (const EventDistribution& pdf1_, const EventDistribution& pdf2_){
     return CompositeED(&pdf1_, &pdf2_);
 }
-
 
 unsigned
 CompositeED::GetNDims() const{
@@ -62,3 +65,14 @@ CompositeED::GetNDims() const{
         nDims += fDistPtrs.at(i)->GetNDims();
     return nDims;
 }
+
+std::string
+CompositeED::GetName() const{
+    return fName;
+}
+
+void
+CompositeED::SetName(const std::string& name_){
+    fName = name_;
+}
+

--- a/src/dist/CompositeED.h
+++ b/src/dist/CompositeED.h
@@ -10,6 +10,7 @@
 #define __COMPOSITE_ED__
 #include <EventDistribution.h>
 #include <vector>
+#include <string>
 
 class Event;
 class CompositeED : public EventDistribution{
@@ -24,8 +25,12 @@ class CompositeED : public EventDistribution{
     virtual double Integral()  const;
     virtual void   Normalise();
     unsigned GetNDims() const;
+
+    std::string GetName() const;
+    void SetName(const std::string&);
+
  private:
-    
+    std::string fName;
     std::vector<EventDistribution*> fDistPtrs;
 };
 

--- a/src/dist/EventDistribution.h
+++ b/src/dist/EventDistribution.h
@@ -16,5 +16,8 @@ class EventDistribution{
     virtual void   Normalise()   = 0;
 
     virtual unsigned GetNDims() const = 0;    
+    
+    virtual std::string GetName() const = 0;
+    virtual void  SetName(const std::string&) = 0;
 };
 #endif

--- a/src/dist/SpectralFitDist.h
+++ b/src/dist/SpectralFitDist.h
@@ -6,7 +6,8 @@
 
 class SpectralFitDist : public BinnedED, public FitComponent{
  public:
-    SpectralFitDist(const AxisCollection& axes_) : BinnedED(axes_) {}
+ SpectralFitDist(const std::string& name_, 
+                 const AxisCollection& axes_) : BinnedED(name_, axes_) {}
 
     // Make this fittable with each bin content adjustable
     void MakeFittable() {}

--- a/src/fitutil/BinnedEDManager.cpp
+++ b/src/fitutil/BinnedEDManager.cpp
@@ -113,7 +113,14 @@ BinnedEDManager::MakeFittable(){
     fParameterManager.Clear();
     if(fNormalisations.size() < fNPdfs)
         fNormalisations.resize(fNPdfs, 0);
-    fParameterManager.AddContainer(fNormalisations, "Pdf Normalisation");
+
+    std::vector<std::string> parameterNames;
+    parameterNames.reserve(fNPdfs);
+
+    for(size_t i = 0; i < fNPdfs; i++)
+        parameterNames.push_back(fOriginalPdfs.at(i).GetName() + "_norm");
+
+    fParameterManager.AddContainer(fNormalisations, parameterNames);
 }
 
 std::vector<std::string>

--- a/src/fitutil/BinnedEDShrinker.cpp
+++ b/src/fitutil/BinnedEDShrinker.cpp
@@ -81,7 +81,7 @@ BinnedEDShrinker::ShrinkDist(const BinnedED& dist_) const{
     }
 
     // 2. Initialise the new pdf with same data rep
-    BinnedED newDist(newAxes);
+    BinnedED newDist(dist_.GetName() + "shrunk", newAxes);
     newDist.SetObservables(dist_.GetObservables());
 
     // 3. Fill the axes

--- a/src/fitutil/BinnedEDShrinker.cpp
+++ b/src/fitutil/BinnedEDShrinker.cpp
@@ -81,7 +81,7 @@ BinnedEDShrinker::ShrinkDist(const BinnedED& dist_) const{
     }
 
     // 2. Initialise the new pdf with same data rep
-    BinnedED newDist(dist_.GetName() + "shrunk", newAxes);
+    BinnedED newDist(dist_.GetName() + "_shrunk", newAxes);
     newDist.SetObservables(dist_.GetObservables());
 
     // 3. Fill the axes


### PR DESCRIPTION
This commit adds a requirement that all implementations of `EventDistribution` have
* `std::string GetName() const`;
* `void SetName(const std::string& name)`
by adding these as PVM directly to the `EventDistribution` interface

* `AnalyticED`, `BinnedED` and `CompositeED` implement this with a private string
* `AnalyticED` and `BinnedED` have the name set in the constructor
* `CompositeED` has a name that is a combination of it's constituents until overwritten
explicitly

* `BinnedEDShrinker` outputs a new `BinnedED` with name `oldname + "_shrunk"`
* `BinnedEDManager` now names its fit parameters `<EDname> + "_norm"`