### PR TITLE
Sum TestStatistics

### DIFF
--- a/src/core/Combinations.hpp
+++ b/src/core/Combinations.hpp
@@ -4,16 +4,23 @@
 #include <vector>
 #include <utility>
 #include <assert.h>
+#include <set>
 
 
 namespace Combinations{
 
 template<typename T1>
-std::vector<std::pair<T1, T1> > AllCombsNoDiag(const std::vector<T1>& v1_){
-    std::vector<std::pair<T1, T1> > pairs;
-    for(size_t i = 0; i < v1_.size(); i++){
-        for(size_t j = 0; j < i; j++){
-            pairs.push_back(make_pair(v1_.at(i), v1_.at(j)));
+std::set<std::pair<typename T1::value_type, typename T1::value_type> > 
+AllCombsNoDiag(const T1& v1_){
+
+    typedef typename T1::value_type ValueType;
+    typedef typename std::set<std::pair<ValueType, ValueType> > SetType;
+    typedef typename T1::const_iterator It; 
+
+    SetType pairs;
+    for(It it1 = v1_.begin(); it1 != v1_.end(); ++it1){
+        for(It it2 = v1_.begin(); it2 != it1; ++it2){
+            pairs.insert(make_pair(*it1, *it2));
         }
     }
     return pairs;
@@ -22,6 +29,7 @@ std::vector<std::pair<T1, T1> > AllCombsNoDiag(const std::vector<T1>& v1_){
 template<typename T1>
 std::vector<T1> Range(const T1& N, const T1& start = 0){
     assert(N > start);
+    
     std::vector<T1> ret;
     ret.reserve(N - start);
     for(T1 i = start; i < N; i++)

--- a/src/core/ComponentManager.cpp
+++ b/src/core/ComponentManager.cpp
@@ -33,7 +33,7 @@ ComponentManager::GetParameters() const{
     return pd;
 }
 
-std::vector<std::string>
+std::set<std::string>
 ComponentManager::GetParameterNames() const{
     return GetKeys(GetParameters());
 }

--- a/src/core/ComponentManager.h
+++ b/src/core/ComponentManager.h
@@ -2,6 +2,7 @@
 #define __OXSX_COMPONENT_MANAGER__
 #include <FitComponent.h>
 #include <vector>
+#include <set>
 #include <string>
 
 class ComponentManager{
@@ -10,7 +11,7 @@ class ComponentManager{
     void AddComponent(FitComponent*);
 
     void SetParameters(const ParameterDict&);
-    std::vector<std::string>  GetParameterNames() const;
+    std::set<std::string>  GetParameterNames() const;
     ParameterDict             GetParameters() const;
     int                       GetTotalParameterCount() const;
     size_t                    GetComponentCount() const;

--- a/src/core/ContainerTools.hpp
+++ b/src/core/ContainerTools.hpp
@@ -9,59 +9,84 @@
 namespace ContainerTools{
 
 template <typename T1, typename T2>
-std::map<T1, T2> VecsToMap(const std::vector<T1>& v1_, const std::vector<T2>& v2_){
+std::map<typename T1::value_type, typename T2::value_type> 
+CreateMap(const T1& v1_, const T2& v2_){
     assert(v1_.size() == v2_.size());
-    
-    std::map<T1, T2> map;
-    for(size_t i = 0; i < v1_.size(); i++)
-        map[v1_.at(i)] = v2_.at(i);
+    typedef typename T1::const_iterator It2;
+    typedef typename T2::const_iterator It3;
+
+    std::map<typename T1::value_type, typename T2::value_type> map;
+
+
+    It2 it1 = v1_.begin();
+    It3 it2 = v2_.begin();
+
+    for(; it1 != v1_.end();){
+        map[*it1] = *it2;
+        ++it1;
+        ++it2;
+    }    
     return map;
 }
 
-template<typename T1, typename T2>
-std::vector<T1> GetKeys(const std::map<T1, T2> & mp_){
-    typedef typename std::map<T1, T2>::const_iterator mapIt;
+template<typename T1>
+std::set<typename T1::key_type> GetKeys(const T1 & mp_){
+    typedef typename T1::const_iterator MapIt;
+    typedef typename T1::key_type KeyType;
 
-    std::vector<T1> vec;
-    vec.reserve(mp_.size());
-    for(mapIt it = mp_.begin(); it != mp_.end(); ++it){
-        vec.push_back(it->first);        
+    std::set<KeyType> set;
+    for(MapIt it = mp_.begin(); it != mp_.end(); ++it){
+        set.insert(it->first);        
     }
-    return vec;
+    return set;
 }
 
 template<typename T1, typename T2>
-std::vector<T2> GetValues(const std::map<T1, T2>& mp_, const std::vector<T1>& keys_){
+std::vector<typename T1::mapped_type> GetValues(const T1& mp_,
+                                                const T2& keys_){
     // throws std::out_of_range if there is no matching key
-    std::vector<T2> vals;
-    vals.reserve(keys_.size());
-    for(size_t i = 0; i < keys_.size(); i++){    
-            vals.push_back(mp_.at(keys_.at(i)));
+    typedef typename T1::mapped_type SecType;
+    typedef typename T2::const_iterator It;
+
+    std::vector<SecType> vals;
+    for(It it = keys_.begin();  it != keys_.end(); ++it){
+        vals.push_back(mp_.at(*it));
     }
 
     return vals;
 }
 
-template<typename T1, typename T2>
-std::vector<T2> GetValues(const std::map<T1, T2>& mp_){
-    typedef typename std::map<T1, T2>::const_iterator mapIt;
+template<typename T1>
+std::vector<typename T1::mapped_type> GetValues(const T1& mp_){
 
-    std::vector<T2> vec;
-    vec.reserve(mp_.size());
-    for(mapIt it = mp_.begin(); it != mp_.end(); ++it){
-        vec.push_back(it->second);        
+    // throws std::out_of_range if there is no matching key
+    typedef typename T1::const_iterator It;
+
+    std::vector<typename T1::mapped_type> vals;
+    for(It it = mp_.begin();  it != mp_.end(); ++it){
+        vals.push_back(it->second);
     }
-    return vec;
-}
-template<typename T1, typename T2>
-void SetValues(std::map<T1, T2> mp_, const std::vector<T1>& keys_, const std::vector<T2>& values_){
-    typedef typename std::map<T1, T2>::iterator mapIt;
 
+    return vals;
+}
+
+
+template<typename T1, typename T2, typename T3>
+void SetValues(T1& mp_, const T2& keys_, const T3& values_){
     assert(mp_.size() == keys_.size());
     assert(values_.size() == keys_.size());
-    size_t index = 0;
-    for(size_t i = 0; i < keys_.size(); i++)
-        mp_[keys_.at(i)] = values_.at(i);
+
+    typedef typename T2::const_iterator It2;
+    typedef typename T3::const_iterator It3;
+
+    It2 it2 = keys_.begin();
+    It3 it3 = values_.begin();
+
+    for(; it2 != keys_.end();){
+        mp_[*it2] = *it3;
+        ++it2;
+        ++it3;
+    }
 }
 
 
@@ -75,15 +100,15 @@ bool HasKey(const std::map<T1, T2>& mp_, const T1& key_){
     return mp_.find(key_) != mp_.end();
 }
 
-template<typename T1, typename T2, typename T3>
-std::string CompareKeys(const std::map<T1, T2>& m1_, const std::map<T1, T3>& m2_, const std::string name1_ = "p1", const std::string& name2_ = "p2"){
+template<typename T1, typename T2>
+std::string CompareKeys(const T1& m1_, const T2& m2_, const std::string name1_ = "p1", const std::string& name2_ = "p2"){
     // nothing doing
     if(HasSameKeys(m1_, m2_))
         return name1_ + " and " + name2_ + " have the same keys";
-
-    typename std::vector<T1> missingFrom2;
     
-    typedef typename std::map<T1, T2>::const_iterator mapIt;
+    typename std::vector<typename T1::key_type> missingFrom2;
+    
+    typedef typename T1::const_iterator mapIt;
 
     for(mapIt it = m1_.begin(); it != m1_.end(); ++it){
         if(!HasKey(m2_, it->first))

--- a/src/core/FitComponent.h
+++ b/src/core/FitComponent.h
@@ -1,6 +1,7 @@
 #ifndef __OXSX_FIT_COMPONENT__
 #define __OXSX_FIT_COMPONENT__
 #include <vector>
+#include <set>
 #include <string>
 #include <ParameterDict.h>
 
@@ -15,7 +16,7 @@ class FitComponent{
     virtual ParameterDict GetParameters() const = 0;
     virtual size_t GetParameterCount() const  = 0;
 
-    virtual std::vector<std::string> GetParameterNames() const = 0;
+    virtual std::set<std::string> GetParameterNames() const = 0;
     virtual void   RenameParameter(const std::string& old_, const std::string& new_) = 0;
 
     virtual std::string GetName() const = 0;

--- a/src/core/ParameterManager.cpp
+++ b/src/core/ParameterManager.cpp
@@ -34,7 +34,7 @@ ParameterManager::GetParameters() const{
     return returnD;
 }
 
-std::vector<std::string>
+std::set<std::string>
 ParameterManager::GetParameterNames() const{
     return GetKeys(fParamPtrs);
 }

--- a/src/core/ParameterManager.h
+++ b/src/core/ParameterManager.h
@@ -2,6 +2,7 @@
 #define __OXSX_PARAMETER_MANAGER__
 #include <vector>
 #include <map>
+#include <set>
 #include <string>
 #include <iostream>
 #include <ParameterDict.h>
@@ -35,7 +36,7 @@ class ParameterManager{
     ParameterDict  GetParameters() const;
     virtual size_t GetParameterCount() const;
 
-    virtual std::vector<std::string> GetParameterNames() const;
+    virtual std::set<std::string> GetParameterNames() const;
     virtual void   RenameParameter(const std::string& old_, const std::string& new_);
 
  private:

--- a/src/dist/AnalyticED.cpp
+++ b/src/dist/AnalyticED.cpp
@@ -123,7 +123,7 @@ AnalyticED::GetParameterCount() const{
     return fFunction->GetParameterCount();
 }
 
-std::vector<std::string>
+std::set<std::string>
 AnalyticED::GetParameterNames() const{
     return fFunction->GetParameterNames();
 }

--- a/src/dist/AnalyticED.h
+++ b/src/dist/AnalyticED.h
@@ -35,7 +35,7 @@ class AnalyticED : public EventDistribution, public FitComponent{
     ParameterDict GetParameters() const;
     size_t GetParameterCount() const;
 
-    std::vector<std::string> GetParameterNames() const;
+    std::set<std::string> GetParameterNames() const;
     void   RenameParameter(const std::string& old_, const std::string& new_);
     
  private:

--- a/src/dist/SpectralFitDist.cpp
+++ b/src/dist/SpectralFitDist.cpp
@@ -4,8 +4,10 @@
 #include <ContainerTools.hpp>
 #include <sstream>
 #include <algorithm>
+#include <iostream>
+
 using ContainerTools::ToString;
-using ContainerTools::VecsToMap;
+using ContainerTools::CreateMap;
 
 // JD: this will probably be too slow one day - there is overkill checking here.
 // you can just set all of the bin contents in one go, but noone needs this code yet
@@ -34,7 +36,6 @@ SpectralFitDist::GetParameter(const std::string& name_) const{
     std::vector<std::string>::const_iterator it = std::find(fBinNames.begin(), fBinNames.end(), name_);
     if(it == fBinNames.end())
         throw ParameterError("Can't get " + name_ + ", parameters are called: \n " + ToString(fBinNames));
-
     return fHistogram.GetBinContent(it - fBinNames.begin());
 }
     
@@ -46,12 +47,12 @@ SpectralFitDist::SetParameters(const ParameterDict& pd_){
             }
             catch(const std::out_of_range& e_){
                 throw ParameterError("Set Parameters: Couldn't set bin content " + fBinNames.at(i));
-            }    
+            }
 }
 
 ParameterDict
 SpectralFitDist::GetParameters() const{
-    return VecsToMap(fBinNames, fHistogram.GetBinContents());
+    return CreateMap(fBinNames, fHistogram.GetBinContents());
 }
 
 size_t
@@ -59,9 +60,9 @@ SpectralFitDist::GetParameterCount() const{
     return fHistogram.GetNBins();
 }
     
-std::vector<std::string>
+std::set<std::string>
 SpectralFitDist::GetParameterNames() const{
-    return fBinNames;
+    return std::set<std::string>(fBinNames.begin(), fBinNames.end());
 }
 
 void

--- a/src/dist/SpectralFitDist.h
+++ b/src/dist/SpectralFitDist.h
@@ -16,7 +16,7 @@ class SpectralFitDist : public BinnedED, public FitComponent{
     ParameterDict GetParameters() const;
     size_t GetParameterCount() const;
     
-    std::vector<std::string> GetParameterNames() const;
+    std::set<std::string> GetParameterNames() const;
     void   RenameParameter(const std::string& old_, const std::string& new_);
 
 

--- a/src/eventSystematic/EventConvolution.cpp
+++ b/src/eventSystematic/EventConvolution.cpp
@@ -114,7 +114,7 @@ EventConvolution::GetParameterCount() const{
     return fDist->GetParameterCount();
 }
 
-std::vector<std::string>
+std::set<std::string>
 EventConvolution::GetParameterNames() const{
     if(!fDist)
         throw NULLPointerAccessError("EventConvolution::GetParameterNames", 

--- a/src/eventSystematic/EventConvolution.h
+++ b/src/eventSystematic/EventConvolution.h
@@ -31,7 +31,7 @@ class EventConvolution : public EventSystematic{
   ParameterDict GetParameters() const;
   size_t GetParameterCount() const;
     
-  std::vector<std::string> GetParameterNames() const;
+  std::set<std::string> GetParameterNames() const;
   void   RenameParameter(const std::string& old_, const std::string& new_);
   
   std::string GetName() const;

--- a/src/eventSystematic/EventReconvolution.cpp
+++ b/src/eventSystematic/EventReconvolution.cpp
@@ -64,9 +64,11 @@ EventReconvolution::GetParameterCount() const{
     return 1;
 }
 
-std::vector<std::string>
+std::set<std::string>
 EventReconvolution::GetParameterNames() const{
-    return std::vector<std::string>(1, fParamName);
+    std::set<std::string> ret;
+    ret.insert(fParamName);
+    return ret;
 }
 
 void

--- a/src/eventSystematic/EventReconvolution.h
+++ b/src/eventSystematic/EventReconvolution.h
@@ -21,7 +21,7 @@ class EventReconvolution : public EventSystematic{
     ParameterDict GetParameters() const;
     size_t GetParameterCount() const;
     
-    std::vector<std::string> GetParameterNames() const;
+    std::set<std::string> GetParameterNames() const;
     void   RenameParameter(const std::string& old_, const std::string& new_);
     
     std::string GetName() const;

--- a/src/eventSystematic/EventScale.cpp
+++ b/src/eventSystematic/EventScale.cpp
@@ -66,9 +66,11 @@ EventScale::GetParameterCount() const{
     return 1;
 }
 
-std::vector<std::string>
+std::set<std::string>
 EventScale::GetParameterNames() const{
-    return std::vector<std::string>(1, fParamName);
+    std::set<std::string> ret;
+    ret.insert(fParamName);
+    return ret;
 }
 
 void

--- a/src/eventSystematic/EventScale.h
+++ b/src/eventSystematic/EventScale.h
@@ -20,7 +20,7 @@ class EventScale : public EventSystematic{
     ParameterDict GetParameters() const;
     size_t GetParameterCount() const;
 
-    std::vector<std::string> GetParameterNames() const;
+    std::set<std::string> GetParameterNames() const;
     void   RenameParameter(const std::string& old_, const std::string& new_);
 
     std::string GetName() const;

--- a/src/eventSystematic/EventShift.cpp
+++ b/src/eventSystematic/EventShift.cpp
@@ -61,9 +61,11 @@ EventShift::GetParameterCount() const{
     return 1;
 }
 
-std::vector<std::string>
+std::set<std::string>
 EventShift::GetParameterNames() const{
-    return std::vector<std::string>(1, fParamName);
+    std::set<std::string> set;
+    set.insert(fParamName);
+    return set;
 }
 
 void

--- a/src/eventSystematic/EventShift.h
+++ b/src/eventSystematic/EventShift.h
@@ -20,7 +20,7 @@ class EventShift : public EventSystematic{
     ParameterDict GetParameters() const;
     size_t GetParameterCount() const;
 
-    std::vector<std::string> GetParameterNames() const;
+    std::set<std::string> GetParameterNames() const;
     void   RenameParameter(const std::string& old_, const std::string& new_);
 
     std::string GetName() const;

--- a/src/fitutil/BinnedEDManager.cpp
+++ b/src/fitutil/BinnedEDManager.cpp
@@ -150,7 +150,7 @@ BinnedEDManager::GetParameterCount() const{
     return fParameterManager.GetParameterCount();
 }
 
-std::vector<std::string>
+std::set<std::string>
 BinnedEDManager::GetParameterNames() const{
     return fParameterManager.GetParameterNames();
 }

--- a/src/fitutil/BinnedEDManager.h
+++ b/src/fitutil/BinnedEDManager.h
@@ -41,7 +41,7 @@ class BinnedEDManager : public FitComponent{
     ParameterDict GetParameters() const;
     size_t GetParameterCount() const;
 
-    std::vector<std::string> GetParameterNames() const;
+    std::set<std::string> GetParameterNames() const;
     void   RenameParameter(const std::string& old_, const std::string& new_);
 
     std::string GetName() const;

--- a/src/fitutil/EDManager.cpp
+++ b/src/fitutil/EDManager.cpp
@@ -115,7 +115,7 @@ EDManager::GetParameterCount() const{
     return fParameterManager.GetParameterCount();
 }
 
-std::vector<std::string>
+std::set<std::string>
 EDManager::GetParameterNames() const{
     return fParameterManager.GetParameterNames();
 }

--- a/src/fitutil/EDManager.h
+++ b/src/fitutil/EDManager.h
@@ -31,7 +31,7 @@ class EDManager : public FitComponent{
     ParameterDict GetParameters() const;
     size_t GetParameterCount() const;
     
-    std::vector<std::string> GetParameterNames() const;
+    std::set<std::string> GetParameterNames() const;
     void   RenameParameter(const std::string& old_, const std::string& new_);
     
     std::string GetName() const;

--- a/src/function/Gaussian.cpp
+++ b/src/function/Gaussian.cpp
@@ -206,7 +206,7 @@ Gaussian::GetParameterCount() const{
     return fParameterManager.GetParameterCount();
 }
 
-std::vector<std::string>
+std::set<std::string>
 Gaussian::GetParameterNames() const{
     return fParameterManager.GetParameterNames();
 }

--- a/src/function/Gaussian.h
+++ b/src/function/Gaussian.h
@@ -39,7 +39,7 @@ class Gaussian : public PDF{
     ParameterDict GetParameters() const;
     size_t GetParameterCount() const;
     
-    std::vector<std::string> GetParameterNames() const;
+    std::set<std::string> GetParameterNames() const;
     void   RenameParameter(const std::string& old_, const std::string& new_);
     
     std::string GetName() const;

--- a/src/function/JumpPDF.cpp
+++ b/src/function/JumpPDF.cpp
@@ -164,7 +164,7 @@ JumpPDF::GetParameterCount() const{
     return fPDF->GetParameterCount();
 }
 
-std::vector<std::string>
+std::set<std::string>
 JumpPDF::GetParameterNames() const{
     if(!fPDF)
          throw NULLPointerAccessError("JumpPDF::Probability",

--- a/src/function/JumpPDF.h
+++ b/src/function/JumpPDF.h
@@ -40,7 +40,7 @@ class JumpPDF : public ConditionalPDF{
   ParameterDict GetParameters() const;
   size_t GetParameterCount() const;
   
-  std::vector<std::string> GetParameterNames() const;
+  std::set<std::string> GetParameterNames() const;
   void   RenameParameter(const std::string& old_, const std::string& new_);
   
   std::string GetName() const;

--- a/src/histogram/HistTools.cpp
+++ b/src/histogram/HistTools.cpp
@@ -4,15 +4,16 @@
 
 std::vector<Histogram>
 HistTools::MakeAllHists(const AxisCollection& axes_,
-                        const std::vector<std::pair<std::string, std::string> >& combinations_){
+                        const std::set<std::pair<std::string, std::string> >& combinations_){
     std::vector<Histogram> hists;
     hists.reserve(combinations_.size());
+    
+    typedef std::set<std::pair<std::string, std::string> >::iterator SetIt;
 
-    for(size_t i = 0; i < combinations_.size(); i++){
-        const std::pair<std::string, std::string>& dims = combinations_.at(i);
+    for(SetIt it = combinations_.begin(); it != combinations_.end(); ++it){
         AxisCollection axes;
-        axes.AddAxis(axes_.GetAxis(dims.first));
-        axes.AddAxis(axes_.GetAxis(dims.second));
+        axes.AddAxis(axes_.GetAxis(it->first));
+        axes.AddAxis(axes_.GetAxis(it->second));
             
         hists.push_back(Histogram(axes));
     }
@@ -25,18 +26,4 @@ HistTools::FillAllHists(std::vector<Histogram>& hists_, const std::map<std::stri
     for(size_t i = 0; i < hists_.size(); i++){
         hists_.at(i).Fill(fillVals_);
     }    
-}
-
-
-std::vector<Histogram> 
-HistTools::MakeAllHists(const AxisCollection& axes_,
-                        const std::vector<std::string>& names_){
-    std::vector<Histogram> hists;
-    hists.reserve(names_.size());
-    for(size_t i = 0; i < names_.size(); i++){
-        AxisCollection axes;
-        axes.AddAxis(axes_.GetAxis(names_.at(i)));
-        hists.push_back(Histogram(axes));
-    }
-    return hists;
 }

--- a/src/histogram/HistTools.h
+++ b/src/histogram/HistTools.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include <map>
 #include <string>
+#include <set>
 
 
 class AxisCollection;
@@ -11,11 +12,14 @@ class Histogram;
 class HistTools{
  public:
     static std::vector<Histogram> MakeAllHists(const AxisCollection&, 
-                                               const std::vector<std::pair<std::string, std::string> >& combinations_);
+                                               const std::set<std::pair<std::string, std::string> >& combinations_);
 
+    template<typename T1>
     static std::vector<Histogram> MakeAllHists(const AxisCollection&, 
-                                               const std::vector<std::string>& names_);
+                                               const T1& names_);
 
     static void FillAllHists(std::vector<Histogram>&, const std::map<std::string, double>& fillvals);
 };
+
+#include <HistTools.hpp>
 #endif

--- a/src/histogram/HistTools.hpp
+++ b/src/histogram/HistTools.hpp
@@ -1,0 +1,18 @@
+#include <AxisCollection.h>
+#include <Histogram.h>
+
+template<typename T1>
+std::vector<Histogram> 
+HistTools::MakeAllHists(const AxisCollection& axes_,
+                        const T1& names_){
+    std::vector<Histogram> hists;
+    hists.reserve(names_.size());
+
+    typedef typename T1::const_iterator It;
+    for(It it = names_.begin(); it != names_.end(); ++it){
+        AxisCollection axes;
+        axes.AddAxis(axes_.GetAxis(*it));
+        hists.push_back(Histogram(axes));
+    }
+    return hists;
+}

--- a/src/optimise/MetropolisHastings.cpp
+++ b/src/optimise/MetropolisHastings.cpp
@@ -158,15 +158,16 @@ MetropolisHastings::Optimise(TestStatistic* testStat_){
 
     // 1. Choose a random starting point or the user defined one
     ParameterDict currentStep;
-    std::vector<std::string> parameterNames = testStat_->GetParameterNames();
+    std::set<std::string> parameterNames = testStat_->GetParameterNames();
     if(fInitialTrial.size())
       currentStep = fInitialTrial;
     else{
-        for(size_t i = 0; i < parameterNames.size(); i++){
-            const std::string& name = parameterNames.at(i);            
+        for(std::set<std::string>::iterator it = parameterNames.begin(); 
+        it != parameterNames.end(); ++it){
+        const std::string& name = *it;
             currentStep[name] = fMinima[name] + Rand::Uniform() * (fMaxima[name] - fMinima[name]);
         }
-    }
+}
 
     std::cout << "Metropolis Hastings::Initial Position @:" << std::endl;
     for(ParameterDict::iterator it = currentStep.begin(); it != currentStep.end(); ++it)
@@ -323,13 +324,14 @@ MetropolisHastings::InitialiseHistograms(){
     
     // otherwise take a guess
     else{
-        std::vector<std::string> paramNames = pTestStatistic->GetParameterNames();
-        for(size_t i = 0; i < fMinima.size(); i++){            
-            const std::string& name = paramNames.at(i);
+        std::set<std::string> paramNames = pTestStatistic->GetParameterNames();
+        for(std::set<std::string>::iterator it =  paramNames.begin();
+            it != paramNames.end(); ++it){
+            const std::string& name = *it;
             double max = fMaxima.at(name);
             if(max == fMinima.at(name))
                 max += 0.01;
-            histAxes.AddAxis(BinAxis(paramNames.at(i), fMinima.at(name), max,
+            histAxes.AddAxis(BinAxis(name, fMinima.at(name), max,
                                      int(pow(fMaxIter, 1./fMinima.size()))));
         }
     }

--- a/src/optimise/MetropolisHastings.h
+++ b/src/optimise/MetropolisHastings.h
@@ -3,6 +3,7 @@
 #include <Optimiser.h>
 #include <FitResult.h>
 #include <Histogram.h>
+#include <set>
 
 class TestStatistic;
 class MetropolisHastings : public Optimiser{
@@ -74,7 +75,7 @@ class MetropolisHastings : public Optimiser{
 
     std::vector<Histogram>           f1DProjections;
     std::vector<Histogram>           f2DProjections;
-    std::vector<std::pair<std::string, std::string> > f2DProjNames;
+    std::set<std::pair<std::string, std::string> > f2DProjNames;
 
     Histogram fHist;
     std::vector< std::vector<double> > fSample;

--- a/src/optimise/Minuit.cpp
+++ b/src/optimise/Minuit.cpp
@@ -93,16 +93,19 @@ Minuit::Initialise(){
                          << "Initial Errors for :\n" << ToString(GetKeys(fInitialErrors)) << "\n"
                          );
     
-    // impose a set ordering on the parameters, so they can be reliably referenced (minuit does vectors we do maps)
     fParameterNames = GetKeys(fInitialErrors);
     
     // Create parameters and set limits
     MnUserParameters params(GetValues(fInitialValues, fParameterNames), GetValues(fInitialErrors, fParameterNames));
 
-    if(fMinima.size() && fMaxima.size())
-        for(size_t i = 0; i < fParameterNames.size(); i++)
-            params.SetLimits(i, fMinima[fParameterNames.at(i)], fMaxima[fParameterNames.at(i)]);
-    
+    if(fMinima.size() && fMaxima.size()){
+        int i = 0;
+        for(std::set<std::string>::iterator it = fParameterNames.begin();
+            it != fParameterNames.end(); ++it){
+            params.SetLimits(i++, fMinima[*it], fMaxima[*it]);
+        }
+    }
+
     if("Migrad" == fMethod)
         fMinimiser = new MnMigrad(fMinuitFCN, params);
     
@@ -162,7 +165,7 @@ Minuit::Optimise(TestStatistic* testStat_){
     // defaults are same as ROOT defaults
     ROOT::Minuit2::FunctionMinimum fnMin  = fMinimiser -> operator()(fMaxCalls, fTolerance); 
 
-    fFitResult.SetBestFit(ContainerTools::VecsToMap(fParameterNames, fMinimiser -> Params()));
+    fFitResult.SetBestFit(ContainerTools::CreateMap(fParameterNames, fMinimiser -> Params()));
     fFitResult.SetValid(fnMin.IsValid());
     return fFitResult;
 }

--- a/src/optimise/Minuit.h
+++ b/src/optimise/Minuit.h
@@ -10,7 +10,7 @@
 #include <MinuitFCN.h>
 #include <Minuit2/MnApplication.h>
 #include <FitResult.h>
-#include <set>
+
 class TestStatistic;
 
 class Minuit : public Optimiser{
@@ -67,7 +67,7 @@ class Minuit : public Optimiser{
     std::string fMethod;
     ROOT::Minuit2::MnApplication* fMinimiser;
 
-    std::vector<std::string> fParameterNames; 
+    std::set<std::string> fParameterNames; 
     // the order they are held in vectors for ROOT
 
     FitResult fFitResult;

--- a/src/optimise/MinuitFCN.h
+++ b/src/optimise/MinuitFCN.h
@@ -11,7 +11,7 @@
 class MinuitFCN : public ROOT::Minuit2::FCNBase{
  public:
     MinuitFCN() :pTestStatistic(NULL), fUp(0.5), fFlipSign(false) {}
-    MinuitFCN(TestStatistic* statistic_, const std::vector<std::string>& names_) : pTestStatistic(statistic_), 
+    MinuitFCN(TestStatistic* statistic_, const std::set<std::string>& names_) : pTestStatistic(statistic_),
                                                                                    fUp(0.5), fFlipSign(false),
                                                                                    fParameterNames(names_){}
     // the second argument above is to absolutely ensure that the parameters are interpreted in the right order
@@ -22,7 +22,7 @@ class MinuitFCN : public ROOT::Minuit2::FCNBase{
         if(!pTestStatistic)
             throw NULLPointerAccessError("Minuit is trying to optimise a NULL TestStatistic* !");
         
-        ContainerTools::SetValues(fSetParameters, fParameterNames, paramVals_);
+        //        ContainerTools::SetValues(fSetParameters, fParameterNames, paramVals_);
         pTestStatistic->SetParameters(fSetParameters);
         if(fFlipSign)
             return -1 * pTestStatistic->Evaluate();
@@ -42,7 +42,7 @@ class MinuitFCN : public ROOT::Minuit2::FCNBase{
     double fUp;
     bool   fFlipSign;  // if true, result is multiplied by -ve 1. changes minimisation to maximisation
     ParameterDict fSetParameters; // edit this map in place to avoid recreating it constantly
-    std::vector<std::string> fParameterNames;
+    std::set<std::string> fParameterNames;
 
     void Initialise(){fSetParameters = pTestStatistic -> GetParameters();}
     

--- a/src/systematic/Convolution.cpp
+++ b/src/systematic/Convolution.cpp
@@ -151,7 +151,7 @@ Convolution::GetParameterCount() const{
     return fDist->GetParameterCount();
 }
 
-std::vector<std::string>
+std::set<std::string>
 Convolution::GetParameterNames() const{
     return fDist->GetParameterNames();
 }

--- a/src/systematic/Convolution.h
+++ b/src/systematic/Convolution.h
@@ -28,7 +28,7 @@ class Convolution : public Systematic{
     ParameterDict GetParameters() const;
     size_t GetParameterCount() const;
 
-    std::vector<std::string> GetParameterNames() const;
+    std::set<std::string> GetParameterNames() const;
     void   RenameParameter(const std::string& old_, const std::string& new_);
 
     std::string GetName() const;

--- a/src/systematic/Scale.cpp
+++ b/src/systematic/Scale.cpp
@@ -125,9 +125,11 @@ Scale::GetParameterCount() const{
     return 1;
 }
 
-std::vector<std::string>
+std::set<std::string>
 Scale::GetParameterNames() const{
-    return std::vector<std::string>(1, fParamName);
+    std::set<std::string> set;
+    set.insert(fParamName);
+    return set;
 }
 
 void

--- a/src/systematic/Scale.h
+++ b/src/systematic/Scale.h
@@ -22,7 +22,7 @@ class Scale : public Systematic{
     ParameterDict GetParameters() const;
     size_t GetParameterCount() const;
 
-    std::vector<std::string> GetParameterNames() const;
+    std::set<std::string> GetParameterNames() const;
     void   RenameParameter(const std::string& old_, const std::string& new_);
 
     std::string GetName() const;

--- a/src/teststat/BinnedNLLH.cpp
+++ b/src/teststat/BinnedNLLH.cpp
@@ -215,7 +215,7 @@ BinnedNLLH::GetParameterCount() const{
     return fComponentManager.GetTotalParameterCount();
 }
 
-std::vector<std::string>
+std::set<std::string>
 BinnedNLLH::GetParameterNames() const{
     return fComponentManager.GetParameterNames();
 }

--- a/src/teststat/BinnedNLLH.h
+++ b/src/teststat/BinnedNLLH.h
@@ -58,7 +58,7 @@ class BinnedNLLH : public TestStatistic{
     void SetParameters(const ParameterDict&);
     ParameterDict GetParameters() const;
     int  GetParameterCount() const;
-    std::vector<std::string> GetParameterNames() const;
+    std::set<std::string> GetParameterNames() const;
     double Evaluate();
 
  private:

--- a/src/teststat/ChiSquare.cpp
+++ b/src/teststat/ChiSquare.cpp
@@ -73,7 +73,7 @@ ChiSquare::GetParameterCount() const{
     return fComponentManager.GetTotalParameterCount();
 }
 
-std::vector<std::string>
+std::set<std::string>
 ChiSquare::GetParameterNames() const{
     return fComponentManager.GetParameterNames();
 }

--- a/src/teststat/ChiSquare.h
+++ b/src/teststat/ChiSquare.h
@@ -24,7 +24,7 @@ class ChiSquare : public TestStatistic{
     int    GetParameterCount() const;
     void   SetParameters(const ParameterDict& params_);
     ParameterDict GetParameters() const;
-    std::vector<std::string> GetParameterNames() const;
+    std::set<std::string> GetParameterNames() const;
     
  private:
     bool              fCalculatedDataDist;

--- a/src/teststat/StatisticSum.cpp
+++ b/src/teststat/StatisticSum.cpp
@@ -1,0 +1,64 @@
+#include <StatisticSum.h>
+#include <ContainerTools.hpp>
+
+StatisticSum::StatisticSum(TestStatistic& s1_, TestStatistic& s2_){
+    AddStat(s1_);
+    AddStat(s2_);
+}
+
+double
+StatisticSum::Evaluate(){
+    double sum = 0;
+    for(size_t i = 0; i < fStats.size(); i++)
+        sum += fStats.at(i) -> Evaluate();
+    return sum;
+}
+
+void
+StatisticSum::SetParameters(const ParameterDict& params_){
+    for(size_t i = 0; i < fStats.size(); i++)
+        fStats.at(i) -> SetParameters(params_);
+}
+
+ParameterDict
+StatisticSum::GetParameters() const{
+    ParameterDict combinedParams;
+    for(size_t i = 0; i < fStats.size(); i++){
+        ParameterDict params = fStats.at(i) -> GetParameters();
+        combinedParams.insert(params.begin(), params.end());
+    }
+    return combinedParams;
+}
+
+std::vector<std::string> 
+StatisticSum::GetParameterNames() const{
+    return ContainerTools::GetKeys(GetParameters());
+}
+
+void
+StatisticSum::RegisterFitComponents(){
+    for(size_t i = 0; i < fStats.size(); i++)
+        fStats.at(i)->RegisterFitComponents();
+}
+
+void 
+StatisticSum::AddStat(TestStatistic& st_){
+    fStats.push_back(&st_);
+}
+
+StatisticSum operator + (TestStatistic& t1_, TestStatistic& t2_){
+    return StatisticSum(t1_, t2_);
+}
+
+StatisticSum operator + (StatisticSum& sum_, TestStatistic& t2_){
+    StatisticSum newSum = sum_;
+    newSum.AddStat(t2_);
+    return newSum;
+}
+
+StatisticSum Sum(const std::vector<TestStatistic*>& stats_){
+    StatisticSum newSum;
+    for(size_t i = 0; i < stats_.size(); i++)
+        newSum.AddStat(stats_.at(i));
+    return newSum;
+}

--- a/src/teststat/StatisticSum.cpp
+++ b/src/teststat/StatisticSum.cpp
@@ -30,7 +30,7 @@ StatisticSum::GetParameters() const{
     return combinedParams;
 }
 
-std::vector<std::string> 
+std::set<std::string> 
 StatisticSum::GetParameterNames() const{
     return ContainerTools::GetKeys(GetParameters());
 }
@@ -46,6 +46,14 @@ StatisticSum::AddStat(TestStatistic& st_){
     fStats.push_back(&st_);
 }
 
+int 
+StatisticSum::GetParameterCount() const{
+    // the teststastics can share parameters so this isn't a simple sum    
+    return GetParameters().size();
+}
+
+// Free operator overlaads
+
 StatisticSum operator + (TestStatistic& t1_, TestStatistic& t2_){
     return StatisticSum(t1_, t2_);
 }
@@ -56,9 +64,12 @@ StatisticSum operator + (StatisticSum& sum_, TestStatistic& t2_){
     return newSum;
 }
 
-StatisticSum Sum(const std::vector<TestStatistic*>& stats_){
+StatisticSum operator + (TestStatistic& t_, StatisticSum& sum_){
+    return sum_ + t_;
+}
+StatisticSum Sum(std::vector<TestStatistic*>& stats_){
     StatisticSum newSum;
     for(size_t i = 0; i < stats_.size(); i++)
-        newSum.AddStat(stats_.at(i));
+        newSum.AddStat(*stats_.at(i));
     return newSum;
 }

--- a/src/teststat/StatisticSum.h
+++ b/src/teststat/StatisticSum.h
@@ -1,6 +1,12 @@
+/* 
+Note that this object is formed without copying the statistics to add
+This means is should exist in the same scope as those summed.
+*/
+
 #ifndef __OXSX_SUMMED_STATISTIC__
 #define __OXSX_SUMMED_STATISTIC__
 #include <TestStatistic.h>
+#include <vector>
 
 class StatisticSum : public TestStatistic{
  public:
@@ -14,7 +20,7 @@ class StatisticSum : public TestStatistic{
     virtual ParameterDict GetParameters() const;
     virtual int    GetParameterCount() const;
 
-    virtual std::vector<std::string> GetParameterNames() const;
+    virtual std::set<std::string> GetParameterNames() const;
     
     // Set up all the components for a fit
     virtual void RegisterFitComponents();
@@ -24,6 +30,6 @@ class StatisticSum : public TestStatistic{
 };
 
 StatisticSum operator + (TestStatistic&, TestStatistic&);
-StatisticSum operator + (const StatisticSum&, TestStatistic&);
-StatisticSum Sum(const std::vector<TestStatistic*>&);
+StatisticSum operator + (StatisticSum&, TestStatistic&);
+StatisticSum Sum(std::vector<TestStatistic*>&);
 #endif

--- a/src/teststat/StatisticSum.h
+++ b/src/teststat/StatisticSum.h
@@ -1,0 +1,29 @@
+#ifndef __OXSX_SUMMED_STATISTIC__
+#define __OXSX_SUMMED_STATISTIC__
+#include <TestStatistic.h>
+
+class StatisticSum : public TestStatistic{
+ public:
+    StatisticSum() {}
+    StatisticSum(TestStatistic&, TestStatistic&);
+    void AddStat(TestStatistic&);
+
+    // Test Statistic Interface
+    virtual double Evaluate();
+    virtual void   SetParameters(const ParameterDict& params_);
+    virtual ParameterDict GetParameters() const;
+    virtual int    GetParameterCount() const;
+
+    virtual std::vector<std::string> GetParameterNames() const;
+    
+    // Set up all the components for a fit
+    virtual void RegisterFitComponents();
+    
+ private:
+    std::vector<TestStatistic*> fStats;
+};
+
+StatisticSum operator + (TestStatistic&, TestStatistic&);
+StatisticSum operator + (const StatisticSum&, TestStatistic&);
+StatisticSum Sum(const std::vector<TestStatistic*>&);
+#endif

--- a/src/teststat/TestStatistic.h
+++ b/src/teststat/TestStatistic.h
@@ -5,7 +5,7 @@
 /****************************************************************************/
 #ifndef __OXSX_TEST_STATISTIC__
 #define __OXSX_TEST_STATISTIC__
-#include <vector>
+#include <set>
 #include <ParameterDict.h>
 #include <string>
 #include <stddef.h>
@@ -19,7 +19,7 @@ class TestStatistic{
     virtual ParameterDict GetParameters() const = 0;
     virtual int    GetParameterCount() const = 0;
 
-    virtual std::vector<std::string> GetParameterNames() const = 0;
+    virtual std::set<std::string> GetParameterNames() const = 0;
     
     // Set up all the components for a fit
     virtual void RegisterFitComponents() = 0;

--- a/test/unit/ComponentManagerTest.cpp
+++ b/test/unit/ComponentManagerTest.cpp
@@ -2,6 +2,7 @@
 #include <ComponentManager.h>
 #include <SpectralFitDist.h>
 #include <Formatter.hpp>
+#include <iostream>
 
 TEST_CASE("Stand alone component manager"){
     // some fake objects
@@ -15,7 +16,7 @@ TEST_CASE("Stand alone component manager"){
     SECTION("initialised correctly"){
         REQUIRE(cmpMan.GetTotalParameterCount() == 0);
         REQUIRE(cmpMan.GetParameters() == ParameterDict());
-        REQUIRE(cmpMan.GetParameterNames() == std::vector<std::string> (0));
+        REQUIRE(cmpMan.GetParameterNames() == std::set<std::string>());
     }
     
     SECTION("adding a component"){
@@ -40,18 +41,19 @@ TEST_CASE("Stand alone component manager"){
         params.insert(params2.begin(), params2.end());
         
         cmpMan.SetParameters(params);
+        
         REQUIRE(pdf1.GetParameters() == params1);
         REQUIRE(pdf2.GetParameters() == params2);
     }
     SECTION("clearing"){
         REQUIRE(cmpMan.GetTotalParameterCount() == 0);
         REQUIRE(cmpMan.GetParameters() == ParameterDict());
-        REQUIRE(cmpMan.GetParameterNames() == std::vector<std::string> (0));
+        REQUIRE(cmpMan.GetParameterNames() == std::set<std::string>());
     }
     SECTION("getting parameter by name"){
         cmpMan.AddComponent(&pdf1);
-        REQUIRE(cmpMan.GetParameter("test1_bin_1") == 0);
+        REQUIRE(cmpMan.GetParameter("test1_bin_1") == Approx(0.));
         pdf1.SetBinContent(0, 10);
-        REQUIRE(cmpMan.GetParameter("test1_bin_0") == 10);        
+        REQUIRE(cmpMan.GetParameter("test1_bin_0") == Approx(10.));
     }
 }

--- a/test/unit/DataSetIOTest.cpp
+++ b/test/unit/DataSetIOTest.cpp
@@ -9,9 +9,7 @@ TEST_CASE("Writing a data set to disk  and reading back"){
     OXSXDataSet origDataSet;
     std::vector<double> eventObs(4);
 
-    for(unsigned i = 0; i < 2181126; i++){
-        if(!(i%1000000))
-            std::cout << 100. * i/2181126 << " % " << std::endl;
+    for(unsigned i = 0; i < 21811; i++){
         for(size_t j = 0; j < eventObs.size(); j++)
             eventObs[j] = j;
         
@@ -28,7 +26,7 @@ TEST_CASE("Writing a data set to disk  and reading back"){
     
     IO::SaveDataSet(origDataSet, "data_set_io_root_test.h5");
     OXSXDataSet* loadedSet = IO::LoadDataSet("data_set_io_root_test.h5");
-	size_t nEntries = origDataSet.GetNEntries();
+    size_t nEntries = origDataSet.GetNEntries();
 
     SECTION("Names copied correctly"){
         REQUIRE(origDataSet.GetObservableNames() == loadedSet->GetObservableNames());

--- a/test/unit/EDManagerTest.cpp
+++ b/test/unit/EDManagerTest.cpp
@@ -63,15 +63,17 @@ TEST_CASE("Add a couple of analytic pdfs"){
         testPs["g2_norm"] = 0;
         REQUIRE(pdfMan.GetParameters() == testPs);
         
-        std::vector<std::string> expectedNames;
-        expectedNames.push_back("g1_norm");
-        expectedNames.push_back("g2_norm");
+        std::set<std::string> expectedNames;
+        expectedNames.insert("g1_norm");
+        expectedNames.insert("g2_norm");
         REQUIRE(pdfMan.GetParameterNames() == expectedNames);
         
         testPs["g1_norm"] = 10;
         testPs["g2_norm"] = 15;
         pdfMan.SetParameters(testPs);
         REQUIRE(pdfMan.GetParameters()     == testPs);
+        // note the line below only works because the normalisations
+        // happen to be in alphabetical order.. don't assume this generally
         REQUIRE(pdfMan.GetNormalisations() == ContainerTools::GetValues(testPs));
     }
 }

--- a/test/unit/HistToolsTest.cpp
+++ b/test/unit/HistToolsTest.cpp
@@ -14,14 +14,16 @@ TEST_CASE("Producing  histograms from a set of axes"){
     
     std::vector<std::string> dimensionList = axes.GetAxisNames();
 
-
     SECTION("2D"){
-        std::vector<std::pair<std::string, std::string> >l2combinations =  Combinations::AllCombsNoDiag<std::string>(dimensionList);
+        typedef std::set<std::pair<std::string, std::string> > CombSet;
+        CombSet l2combinations =  Combinations::AllCombsNoDiag(dimensionList);
         
         std::vector<Histogram> hists = HistTools::MakeAllHists(axes, l2combinations);
-        for(size_t i = 0; i < hists.size(); i++){
-            REQUIRE(hists.at(i).GetAxes().GetAxis(0).GetName() == l2combinations.at(i).first);
-            REQUIRE(hists.at(i).GetAxes().GetAxis(1).GetName() == l2combinations.at(i).second);
+        int i = 0;
+        for(CombSet::iterator it = l2combinations.begin(); it != l2combinations.end(); ++it){
+            REQUIRE(hists.at(i).GetAxes().GetAxis(0).GetName() == it->first);
+            REQUIRE(hists.at(i).GetAxes().GetAxis(1).GetName() == it->second);
+            i++;
         }
     
     }

--- a/test/unit/ParameterManagerTest.cpp
+++ b/test/unit/ParameterManagerTest.cpp
@@ -56,8 +56,8 @@ TEST_CASE("Do parameters register correctly?"){
             expectedNames.insert(ss.str());
         }
 
-        std::vector<std::string> names = paramMan.GetParameterNames();
-        REQUIRE(std::set<std::string>(names.begin(), names.end()) == expectedNames);
+        std::set<std::string> names = paramMan.GetParameterNames();
+        REQUIRE(names == expectedNames);
 
     }
 

--- a/test/unit/StatisticSumTest.cpp
+++ b/test/unit/StatisticSumTest.cpp
@@ -1,0 +1,83 @@
+#include <catch.hpp>
+#include <StatisticSum.h>
+
+class FakeStatistic : public TestStatistic{
+public:
+    double Evaluate() {
+        return fVal;
+    }
+
+    int GetParameterCount() const {
+        return 1;
+    }
+
+    void SetParameters(const ParameterDict& p){
+        fVal = p.at(fParamName);
+    }
+
+    ParameterDict GetParameters() const{
+        ParameterDict p; 
+        p[fParamName] = fVal;
+        return p;
+    } 
+
+    std::vector<std::string> GetParameterNames() const{
+        return std::vector<std::string>(1, fParamName);
+    }
+
+    void RegisterFitComponents() {}
+
+    double fVal;
+    std::string fParamName;
+};
+
+TEST_CASE("Adding test statistics using StatisticSum constr"){
+    FakeStatistic s1;
+    FakeStatistic s2;
+    
+    s1.fVal = 1;
+    s1.fParamName = "p1";
+    s2.fVal = 2;
+    s2.fParamName = "p2";
+
+    SECTION("no shared parameters"){
+        StatisticSum sum(s1, s2);
+        REQUIRE(sum.GetParameterCount() == 2);
+        std::vector<std::string> expectedNames;
+        expectedNames.push_back("p1");
+        expectedNames.push_back("p2");
+
+        ParameterDict expectedVals;
+        expectedVals["p1"] = 1;
+        expectedVals["p2"] = 2;
+
+        REQUIRE(sum.GetParameters() == expectedVals);
+        REQUIRE(sum.GetParameterNames() == expectedNames);
+
+        REQUIRE(sum.Evaluate() == 3); // 2 + 1
+    
+        ParameterDict setVals;
+        setVals["p1"] = 3;
+        setVals["p2"] = 4;
+
+        sum.SetParameters(setVals);
+        REQUIRE(s1.fVal == 3);
+        REQUIRE(s2.fVal == 4);
+        
+        REQUIRE(sum.Evaluate() == 7); // 3 + 4
+    }
+    
+    SECTION("setting with shared parameters"){
+        StatisticSum sum(s1, s2);
+        s1.fParamName = "p2";
+
+        REQUIRE(sum.GetParameterNames() == std::vector<std::string>(1, "p2"));        
+        REQUIRE(sum.GetParameterCount() == 1);
+
+
+        ParameterDict p;
+        p["p1"] = 10;
+        REQUIRE(sum.Evaluate() == 20); // 10 + 10
+        
+    }
+}

--- a/test/unit/StatisticSumTest.cpp
+++ b/test/unit/StatisticSumTest.cpp
@@ -21,8 +21,10 @@ public:
         return p;
     } 
 
-    std::vector<std::string> GetParameterNames() const{
-        return std::vector<std::string>(1, fParamName);
+    std::set<std::string> GetParameterNames() const{
+        std::set<std::string> set;
+        set.insert(fParamName);
+        return set;
     }
 
     void RegisterFitComponents() {}
@@ -43,9 +45,9 @@ TEST_CASE("Adding test statistics using StatisticSum constr"){
     SECTION("no shared parameters"){
         StatisticSum sum(s1, s2);
         REQUIRE(sum.GetParameterCount() == 2);
-        std::vector<std::string> expectedNames;
-        expectedNames.push_back("p1");
-        expectedNames.push_back("p2");
+        std::set<std::string> expectedNames;
+        expectedNames.insert("p1");
+        expectedNames.insert("p2");
 
         ParameterDict expectedVals;
         expectedVals["p1"] = 1;
@@ -70,14 +72,59 @@ TEST_CASE("Adding test statistics using StatisticSum constr"){
     SECTION("setting with shared parameters"){
         StatisticSum sum(s1, s2);
         s1.fParamName = "p2";
-
-        REQUIRE(sum.GetParameterNames() == std::vector<std::string>(1, "p2"));        
+        std::set<std::string> expectedNames;
+        expectedNames.insert("p2");
+        REQUIRE(sum.GetParameterNames() == expectedNames);
         REQUIRE(sum.GetParameterCount() == 1);
 
 
         ParameterDict p;
-        p["p1"] = 10;
+        p["p2"] = 10;
+        sum.SetParameters(p);
         REQUIRE(sum.Evaluate() == 20); // 10 + 10
         
     }
+
+    SECTION("adding test stats with +"){
+        StatisticSum sum = s1 + s2;
+        REQUIRE(sum.GetParameterCount() == 2);
+        std::set<std::string> expectedNames;
+        expectedNames.insert("p1");
+        expectedNames.insert("p2");
+
+        ParameterDict expectedVals;
+        expectedVals["p1"] = 1;
+        expectedVals["p2"] = 2;
+
+        REQUIRE(sum.GetParameters() == expectedVals);
+        REQUIRE(sum.GetParameterNames() == expectedNames);
+
+        REQUIRE(sum.Evaluate() == 3); // 2 + 1    
+
+
+        FakeStatistic s3;
+        s3.fVal = 3;
+        s3.fParamName = "p3";
+
+        StatisticSum sum2 = sum + s3;
+        StatisticSum sum3 = s3 + sum;
+
+        REQUIRE(sum2.Evaluate() == 6);
+        REQUIRE(sum3.Evaluate() == 6);
+    }
+
+    SECTION("Test stat sum operator"){
+        FakeStatistic s3;
+        s3.fVal = 3;
+        s3.fParamName = "p3";
+
+        std::vector<TestStatistic*> stats;
+        stats.push_back(&s1);
+        stats.push_back(&s2);
+        stats.push_back(&s3);
+
+        StatisticSum sum = Sum(stats);
+        REQUIRE(sum.Evaluate() == 6);
+    }
+
 }


### PR DESCRIPTION
Two major changes to make way for joint LH

* `TestStat::GetParameterNames` and `FitComponent::GetParameterNames` now return a `std::set` rather than a `std::vector` to ensure that parameters with the same name are considered the same logical object.

* Added the `StatisticSum` test statistic, which is the sum of any number of test statistics and operators to allow for intuitive manipulation:

```BinnedNLLH lh1;
BinnedNLLH lh2;
StatisticSum jointLH = lh1 + lh2;
some_optimiser ->Optimise(&jointLH);

BinnedNLLH lh3;
StatisticSum jointLH2 = jointLH + lh3;
```
etc.


Also did a decent amount of template fiddling in `ContainerTools` so that the functions mostly now work with most stl containers

@BillyLiggins 