### PR TITLE
Fixed labels in matrix methods so it is consistently (row, col)

### DIFF
--- a/src/core/DenseMatrix.cpp
+++ b/src/core/DenseMatrix.cpp
@@ -4,35 +4,35 @@
 #include <Formatter.hpp>
 
 // initalise to zeros
-DenseMatrix::DenseMatrix(int cols_, int rows_){
+DenseMatrix::DenseMatrix(int rows_, int cols_){
     fNCols = cols_;
     fNRows = rows_;
-    fArmaMat = arma::mat(cols_, rows_, arma::fill::zeros);
+    fArmaMat = arma::mat(rows_, cols_, arma::fill::zeros);
 }
 
 void 
-DenseMatrix::SetComponent(size_t col_, size_t row_, double val_){
+DenseMatrix::SetComponent(size_t row_, size_t col_, double val_){
     if (col_ >= fNCols || row_ >= fNRows)
         throw NotFoundError(Formatter()
                             << "Attempted out of bounds access on  matrix ("
                             << row_ <<  "," << col_ << ")."
-                            << "Matrix is (" << fNCols << "x" << fNRows
+                            << "Matrix is (" << fNRows << "x" << fNCols
                             << ")"
                             );
             
-    fArmaMat(col_,row_) = val_;
+    fArmaMat(row_,col_) = val_;
 }
 
 double 
-DenseMatrix::GetComponent(size_t col_, size_t row_) const{
+DenseMatrix::GetComponent(size_t row_, size_t col_) const{
     if (col_ >= fNCols || row_ >= fNRows)
         throw NotFoundError(Formatter()
                             << "Attempted out of bounds access on  matrix ("
                             << row_ <<  "," << col_ << ")."
-                            << "Matrix is (" << fNCols << "x" << fNRows
+                            << "Matrix is (" << fNRows << "x" << fNCols
                             << ")"
                             );
-    return fArmaMat(col_, row_);
+    return fArmaMat(row_, col_);
 }
 
 std::vector<double>
@@ -46,7 +46,7 @@ DenseMatrix::operator() (const std::vector<double>& input_) const{
         throw DimensionError(Formatter() << "DenseMatrix::opeator() : Input vector ("
                                          << input_.size() << ")" 
                                          << " wrong size for Matrix ("
-                                         << fNCols << "x" << fNRows 
+                                         << fNRows << "x" << fNCols 
                                          << " ) to act on");
     }
 

--- a/src/core/DenseMatrix.h
+++ b/src/core/DenseMatrix.h
@@ -15,13 +15,13 @@ class BinnedPhysDist;
 
 class DenseMatrix{
  public:
-    DenseMatrix() : fNCols(0), fNRows(0) {}
-    DenseMatrix(int cols_, int rows_);
+ DenseMatrix() : fNRows(0), fNCols(0) {}
+    DenseMatrix(int rows_, int cols_);
 
     std::vector<double> operator() (const std::vector<double>& input_) const;
 
-    void   SetComponent(size_t column_, size_t row_, double val_);
-    double GetComponent(size_t column_, size_t row_) const;
+    void   SetComponent(size_t row_, size_t column_, double val_);
+    double GetComponent(size_t row_, size_t column_) const;
     
     DenseMatrix operator*=(const DenseMatrix& other_);
    
@@ -29,8 +29,8 @@ class DenseMatrix{
     void   SetToIdentity();
  private:
     // N x M matrix
-    int fNCols;
     int fNRows;
+    int fNCols;
     arma::mat fArmaMat;
 
 };

--- a/src/core/SparseMatrix.cpp
+++ b/src/core/SparseMatrix.cpp
@@ -4,35 +4,35 @@
 #include  <Formatter.hpp>
 
 // Initialise to zeros
-SparseMatrix::SparseMatrix(int cols_, int rows_){
+SparseMatrix::SparseMatrix(int rows_, int cols_){
     fNCols = cols_;
     fNRows  = rows_; 
-    fArmaMat = arma::sp_mat(fNCols, fNRows);
+    fArmaMat = arma::sp_mat(fNRows, fNCols);
 }
 
 void 
-SparseMatrix::SetComponent(size_t col_, size_t row_, double val_){
+SparseMatrix::SetComponent(size_t row_, size_t col_, double val_){
     if (col_ >= fNCols || row_ >= fNRows)
         throw NotFoundError(Formatter() 
                             << "Attempted out of bounds access on  matrix (" 
                             << row_ <<  "," << col_ << ")."
-                            << "Matrix is (" << fNCols << "x" << fNRows
+                            << "Matrix is (" << fNRows << "x" << fNCols
                             << ")"
                             );
 
-    fArmaMat(col_,row_) = val_; 
+    fArmaMat(row_,col_) = val_;
 }
 
 double 
-SparseMatrix::GetComponent(size_t col_, size_t row_) const{
+SparseMatrix::GetComponent(size_t row_, size_t col_) const{
     if (col_ >= fNCols || row_ >= fNRows)
         throw NotFoundError(Formatter() 
                             << "Attempted out of bounds access on  matrix (" 
                             << row_ <<  "," << col_ << ")."
-                            << "Matrix is (" << fNCols << "x" << fNRows
+                            << "Matrix is (" << fNRows << "x" << fNCols
                             << ")"
                             );
-    return fArmaMat(col_, row_);
+    return fArmaMat(row_, col_);
 }
 
 std::vector<double>
@@ -47,7 +47,7 @@ SparseMatrix::operator() (const std::vector<double>& input_) const{
 ector ("
                              << input_.size() << ")"
                              << " wrong size for Matrix ("
-                             << fNCols << "x" << fNRows
+                             << fNRows << "x" << fNCols
                              << " ) to act on");
     }
 
@@ -69,7 +69,7 @@ SparseMatrix::SetZeros(){
                 "SparseMatrix:: Can't set elements to zero. (rows,cols) : ("<<
                 fNRows<<","<<fNCols<<")"  
                 );
-    fArmaMat = arma::sp_mat(fNCols, fNRows);
+    fArmaMat = arma::sp_mat(fNRows, fNCols);
 }
 
 void

--- a/src/core/SparseMatrix.h
+++ b/src/core/SparseMatrix.h
@@ -16,25 +16,25 @@ class BinnedPhysDist;
 class SparseMatrix{
  public:
     SparseMatrix() : fNRows(0), fNCols(0) {}
-    SparseMatrix(int cols_, int rows_);
+    SparseMatrix(int rows_, int cols_);
     std::vector<double> operator() (const std::vector<double>& input_) const;
 
-    void   SetComponent(size_t column_, size_t row_, double val_);
-    double GetComponent(size_t column_, size_t row_) const;
+    void   SetComponent(size_t row_, size_t column_, double val_);
+    double GetComponent(size_t row_, size_t column_) const;
 
     void   SetComponents(const std::vector<unsigned>& rowIndices_,
                          const std::vector<unsigned>& colIndices_,
                        const std::vector<double>& values_);
 
     SparseMatrix operator*=(const SparseMatrix& other_);
-    size_t GetNCols() const {return fNRows;}
-    size_t GetNRows() const {return fNCols;}
+    size_t GetNRows() const {return fNRows;}
+    size_t GetNCols() const {return fNCols;}
     void   SetZeros();
     void   SetToIdentity();
 
  private:
     arma::sp_mat fArmaMat;
-    int fNCols;
     int fNRows;
+    int fNCols;
 };
 #endif


### PR DESCRIPTION
Changed the methods in DenseMatrix.cpp and DenseMatrix.h so that they all take (row, col) as arguments, rather than the other way around, and pass the arguments onto Armadillo that way. 