### PR TITLE
Add `.ini` parser

### DIFF
--- a/src/config/ConfigLoader.cpp
+++ b/src/config/ConfigLoader.cpp
@@ -1,0 +1,28 @@
+#include <ConfigLoader.hh>
+#include <ContainerTools.hpp>
+#include <Exceptions.h>
+#include <sstream>
+
+INI::Parser* ConfigLoader::fParser = NULL;
+
+void
+ConfigLoader::Load(const std::string& fieldName_,  std::string& loadVal_){
+    loadVal_ = fParser-> top()[fieldName_];
+}
+
+void
+ConfigLoader::Open(const std::string& fileName_){
+    std::ifstream ss;
+    ss.open(fileName_.c_str());
+    if(!ss){        
+        throw IOError("Can't find config file " + fileName_);
+    }
+    delete fParser;
+    fParser = new INI::Parser(ss);
+}
+
+void
+ConfigLoader::Close(){
+    delete fParser;
+    fParser = NULL;
+}

--- a/src/config/ConfigLoader.hh
+++ b/src/config/ConfigLoader.hh
@@ -1,0 +1,72 @@
+// Used to parse .ini configuration files into c++ types
+// Supports all basic types & strings and stl (non-associative) containers except forward_list
+// if used on a container existing elements are not removed
+// example use:
+
+// filename: example.ini
+//
+// myint = 5
+// mystr = hello
+
+// filename: client.cpp
+//
+// #include <ini.hpp>
+// #include <ConfigLoader.hh>
+// #include <string>
+// #include <iostream>
+//
+// ConfigLoader::Open("example.ini");
+// ConfigLoader::Load("myint", myint);
+// ConfigLoader::Load("myint", mystr);
+// ConfigLoader::Close();
+// std::cout << myint == 5 << std::endl; // 1
+// std::cout << mystr == "hello" << std::endl; // 1
+
+#ifndef __OXSX__CONFIG_LOADER__
+#define __OXSX__CONFIG_LOADER__
+#include <TypeTraits.hpp>
+#include <ini.hpp>
+#include <vector>
+#include <string>
+
+using TypeTraits::enable_if;
+using TypeTraits::is_container;
+using TypeTraits::is_number;
+
+class ConfigLoader{
+public:
+    void Open(const std::string& fileName_);
+    void Close();
+    
+    // Fundamental numeric types
+    template<typename TargetType>
+    static void
+    Load(const std::string& fieldName_,  TargetType& loadVal_, typename enable_if<is_number<TargetType>::value, int>::type = 0);
+
+    // another one for containers
+    template<typename TargetType>
+    static void
+    Load(const std::string& fieldName_, TargetType& loadVal_, typename enable_if<is_container<TargetType>::value, int>::type = 0);
+
+    // and one for strings
+    void
+    Load(const std::string& fieldName_,  std::string& loadVal_); 
+
+private:    
+    // nested class performs string conversions
+    template<typename TargetType>
+    struct Converter{
+        TargetType operator()(const std::string& s_) const;
+    };
+
+    // convert a whole container
+    template<typename InContainer, typename OutContainer, typename ConverterSp>
+    static void
+    ConvertContainer(const InContainer& incntr_, OutContainer& outcntr_, const ConverterSp& cnvtr_);
+    
+    static INI::Parser* fParser;
+};
+
+#include <ConfigLoader.hpp>
+    
+#endif

--- a/src/config/ConfigLoader.hpp
+++ b/src/config/ConfigLoader.hpp
@@ -1,0 +1,33 @@
+#include <sstream>
+#include <ContainerTools.hpp>
+
+template<typename TargetType>
+void
+ConfigLoader::Load(const std::string& fieldName_,  TargetType& loadVal_, typename enable_if<is_number<TargetType>::value, int>::type){
+    loadVal_ = Converter<TargetType>()(fParser->top()[fieldName_]);
+}
+
+
+template<typename TargetType>
+void
+ConfigLoader::Load(const std::string& fieldName_, TargetType& loadVal_, typename enable_if<is_container<TargetType>::value, int>::type){
+    typedef typename TargetType::value_type ContainedType;
+    ConvertContainer(ContainerTools::Split(fParser->top()[fieldName_]), loadVal_, Converter<TargetType>());
+}
+
+template<typename TargetType>
+TargetType
+ConfigLoader::Converter<TargetType>::operator()(const std::string& s_) const{
+    std::istringstream buffer(s_);
+    TargetType val;
+    buffer >> val;
+    return val;
+}
+
+template<typename InContainer, typename OutContainer, typename ConverterSp>
+void
+ConfigLoader::ConvertContainer(const InContainer& incntr_, OutContainer& outcntr_, const ConverterSp& cnvtr_){
+    for(typename InContainer::const_iterator it = incntr_.begin(); it != incntr_.end(); ++it){
+        outcntr_.insert(outcntr_.end(), cnvtr_(*it));
+    }
+}

--- a/src/config/ini.hpp
+++ b/src/config/ini.hpp
@@ -1,0 +1,186 @@
+/** 
+ * The MIT License (MIT)
+ * Copyright (c) <2015> <carriez.md@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in 
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+  * 
+  */
+  
+#ifndef INI_HPP
+#define INI_HPP
+
+#include <cassert>
+#include <map>
+#include <list>
+#include <stdexcept>
+#include <string>
+#include <cstring>
+#include <iostream>
+#include <fstream>
+
+namespace INI {
+
+struct Level 
+{
+  Level() : parent(NULL), depth(0) {}
+  Level(Level* p) : parent(p), depth(0) {}
+
+  typedef std::map<std::string, std::string> value_map_t;
+  typedef std::map<std::string, Level> section_map_t;
+  typedef std::list<value_map_t::const_iterator> values_t;
+  typedef std::list<section_map_t::const_iterator> sections_t;
+  value_map_t values;
+  section_map_t sections;
+  values_t ordered_values; // original order in the ini file
+  sections_t ordered_sections;
+  Level* parent;
+  size_t depth;
+
+  const std::string& operator[](const std::string& name) { return values[name]; }
+  Level& operator()(const std::string& name) { return sections[name]; }
+};
+
+class Parser
+{
+public:
+  Parser(const char* fn);
+  Parser(std::istream& f) : f_(&f), ln_(0) { parse(top_); }
+  Level& top() { return top_; }
+  void dump(std::ostream& s) { dump(s, top(), ""); }
+
+private:
+  void dump(std::ostream& s, const Level& l, const std::string& sname);
+  void parse(Level& l);
+  void parseSLine(std::string& sname, size_t& depth);
+  void err(const char* s);
+
+private:
+  Level top_;
+  std::ifstream f0_;
+  std::istream* f_;
+  std::string line_;
+  size_t ln_;
+};
+
+inline void
+Parser::err(const char* s)
+{
+  char buf[256];
+  sprintf(buf, "%s on line #%ld", s, ln_);
+  throw std::runtime_error(buf);
+}
+
+inline std::string trim(const std::string& s)
+{
+  char p[] = " \t\r\n";
+  long sp = 0;
+  long ep = s.length() - 1;
+  for (; sp <= ep; ++sp)
+    if (!strchr(p, s[sp])) break;
+  for (; ep >= 0; --ep)
+    if (!strchr(p, s[ep])) break;
+  return s.substr(sp, ep-sp+1);
+}
+
+inline 
+Parser::Parser(const char* fn) : f0_(fn), f_(&f0_), ln_(0)
+{ 
+  if (!f0_) 
+    throw std::runtime_error(std::string("failed to open file: ") + fn);
+
+  parse(top_); 
+}
+
+inline void 
+Parser::parseSLine(std::string& sname, size_t& depth)
+{
+  depth = 0;
+  for (; depth < line_.length(); ++depth)
+    if (line_[depth] != '[') break;
+
+  sname = line_.substr(depth, line_.length() - 2*depth);
+}
+
+inline void
+Parser::parse(Level& l)
+{
+  while (std::getline(*f_, line_)) {
+    ++ln_;
+    if (line_[0] == '#' || line_[0] == ';') continue;
+    line_ = trim(line_);
+    if (line_.empty()) continue;
+    if (line_[0] == '[') {
+      size_t depth;
+      std::string sname;
+      parseSLine(sname, depth);
+      Level* lp = NULL;
+      Level* parent = &l;
+      if (depth > l.depth + 1)
+        err("section with wrong depth");
+      if (l.depth == depth-1)
+        lp = &l.sections[sname];
+      else {
+        lp = l.parent;
+        size_t n = l.depth - depth;
+        for (size_t i = 0; i < n; ++i) lp = lp->parent;
+        parent = lp;
+        lp = &lp->sections[sname];
+      }
+      if (lp->depth != 0)
+        err("duplicate section name on the same level");
+      if (!lp->parent) {
+        lp->depth = depth;
+        lp->parent = parent;
+      }
+      parent->ordered_sections.push_back(parent->sections.find(sname));
+      parse(*lp);
+    } else {
+      size_t n = line_.find('=');
+      if (n == std::string::npos)
+        err("no '=' found");
+      std::pair<Level::value_map_t::const_iterator, bool> res = 
+        l.values.insert(std::make_pair(trim(line_.substr(0, n)), 
+              trim(line_.substr(n+1, line_.length()-n-1))));
+      if (!res.second)
+        err("duplicated key found");
+      l.ordered_values.push_back(res.first);
+    }
+  }
+}
+
+inline void
+Parser::dump(std::ostream& s, const Level& l, const std::string& sname)
+{
+  if (!sname.empty()) s << '\n';
+  for (size_t i = 0; i < l.depth; ++i) s << '[';
+  if (!sname.empty()) s << sname;
+  for (size_t i = 0; i < l.depth; ++i) s << ']';
+  if (!sname.empty()) s << std::endl;
+  for (Level::values_t::const_iterator it = l.ordered_values.begin(); it != l.ordered_values.end(); ++it)
+    s << (*it)->first << '=' << (*it)->second << std::endl;
+  for (Level::sections_t::const_iterator it = l.ordered_sections.begin(); it != l.ordered_sections.end(); ++it) {
+    assert((*it)->second.depth == l.depth+1);
+    dump(s, (*it)->second, (*it)->first);
+  }
+}
+
+}
+
+#endif // INI_HPP
+

--- a/src/core/TypeTraits.hpp
+++ b/src/core/TypeTraits.hpp
@@ -1,0 +1,69 @@
+#ifndef __OXSX_TYPE_TRAITS__
+#define __OXSX_TYPE_TRAITS__
+#include <limits>
+
+namespace TypeTraits{
+    
+// this is a back port of enable_if from c++11, implementation from c++ docs
+// substitution always works here, regardless of the value of B
+template<bool B, typename T = void>
+struct enable_if {};
+
+// this subsitution can override the previous one if B == true, then it will give it a typedef T
+template<typename T>
+struct enable_if<true, T> { typedef T type; };
+
+// the next three are taken from https://gist.github.com/louisdx/1076849 - credit there
+// does this object have a const iterator
+template<typename T>
+struct has_const_iterator{
+private:
+    typedef char                      one;
+    typedef struct { char array[2]; } two;
+
+    template<typename C> static one test(typename C::const_iterator*);
+    template<typename C> static two  test(...);
+public:
+    static const bool value = sizeof(test<T>(0)) == sizeof(one);
+    typedef T type;
+};
+
+
+
+// does this object have a begin and an end
+template <typename T>
+struct has_begin_end{
+    struct Dummy { typedef void const_iterator; };
+    typedef typename std::conditional<has_const_iterator<T>::value, T, Dummy>::type TType;
+    typedef typename TType::const_iterator iter;
+
+    struct Fallback { iter begin() const; iter end() const; };
+    struct Derived : TType, Fallback { };
+
+    template<typename C, C> struct ChT;
+
+    template<typename C> static char (&f(ChT<iter (Fallback::*)() const, &C::begin>*))[1];
+    template<typename C> static char (&f(...))[2];
+    template<typename C> static char (&g(ChT<iter (Fallback::*)() const, &C::end>*))[1];
+    template<typename C> static char (&g(...))[2];
+
+    static bool const beg_value = sizeof(f<Derived>(0)) == 2;
+    static bool const end_value = sizeof(g<Derived>(0)) == 2;
+};
+
+
+template <typename T>
+struct is_container{
+    static const bool value = has_const_iterator<T>::value &&
+        has_begin_end<T>::beg_value && has_begin_end<T>::end_value;
+};
+
+
+// fundamental data type stuff, use the types for which numeric limits is specialized
+template<typename T>
+struct is_number{
+    static const bool value = std::numeric_limits<T>::is_specialized;
+};
+
+}// namespace
+#endif 


### PR DESCRIPTION
Supports all fundamental (non-pointer) c++ types as well as non-associative stl containers of those types

Example use:

filename: example.ini
```
myint = 1
mychar = 2
mystring = hello
myvec = 1, 2, 3
mset  = 1., 2., 3.
```

filename: client.cpp
```
int main(){
    int myint;
    char mychar;
    std::string mystring;
    std::vector<int> myvec;
    std::set<double> myset;

    ConfigLoader::Open("example.ini");
    ConfigLoader::Load("mychar", mychar);
    ConfigLoader::Load("mystring", mystring);
    ConfigLoader::Load("myvec", myvec);
    ConfigLoader::Load("myset", myset);

    ConfigLoader::Close();

    return 0;
}
```

@BillyLiggins @rcl11  - this is the config system I was talking about before. I might need to go over it one more time before merging, but let me know if there's something major it doesn't cater for

TODO:: add multiple depth levels