### PR TITLE
Add background uncertainty to Bayesian interval calculation

### DIFF
--- a/src/interval/BayesIntervalCalc.cpp
+++ b/src/interval/BayesIntervalCalc.cpp
@@ -65,6 +65,11 @@ BayesIntervalCalc::UpperBound(double expectedCounts_, int observedCounts_, doubl
 
 double 
 BayesIntervalCalc::UpperBound(PDF &b_prob_, double expectedCounts_, double expectedCountsSigma_, int observedCounts_, double cl_){
+    if(cl_ <= 0)
+        throw ValueError(Formatter() << "BayesIntervalCalc:: cl = " << cl_
+                         << " , must be >0!");
+
+    
     // Choose some signal points to test. Try using 50 equally spaced points between 0 and 2*expectedCounts_ (rounded to int)
     int n_sig_points = 50;
     std::vector<double> signals;
@@ -84,12 +89,6 @@ BayesIntervalCalc::UpperBound(PDF &b_prob_, double expectedCounts_, double expec
     //Fill TGraph object with cumulative posterior values to be interpolated for signal at CL=cl_
     TGraph graph = TGraph(n_sig_points,&mlhs[0],&signals[0]);
     
-    for(size_t i=0; i<mlhs.size(); i++) {
-        double x=0.0;
-        double y=0.0;
-        graph.GetPoint(i,x,y);
-        std::cout << "i: " << i <<  ", x: " << x << ", y: " << y << std::endl;
-    }
     //Performs a linear interpolation
     return graph.Eval(cl_);
 }
@@ -111,10 +110,10 @@ double BayesIntervalCalc::Marginalise(PDF& b_prob_, double s, double b, double w
 }
 
 double BayesIntervalCalc::CumulativePosterior(PDF& b_prob, double signal1, double signal2, double b, double width, int n){
-    // Fix signal integral to run between signal1 and signal2 in 10000 steps for now
+    // Fix signal integral to run between signal1 and signal2 in 10000 steps
     int n_sig_points = 10000;
     // Need to compute the total normalisation as well 
-    // Compute normalisation by integrating signal from 0 to 1000(inf) in 10000 steps for now
+    // Compute normalisation by integrating signal from 0 to 1000(inf) in 10000 steps
     int n_norm_sig_points = 10000;
     
     TH1D sig_integral = TH1D("sig","sig",n_sig_points, signal1, signal2);

--- a/src/interval/BayesIntervalCalc.cpp
+++ b/src/interval/BayesIntervalCalc.cpp
@@ -1,6 +1,7 @@
 #include <BayesIntervalCalc.h>
 #include <Exceptions.h>
 #include <Histogram.h>
+#include <TH1D.h>
 #include <gsl/gsl_sf_gamma.h> // imcomplete gamma function
 #include <iostream>
 #include <cmath>
@@ -59,4 +60,101 @@ BayesIntervalCalc::UpperBound(double expectedCounts_, int observedCounts_, doubl
         currentCL = OneSidedUpperInterval(expectedCounts_, observedCounts_, limit);
     }
     return limit;
+}
+
+double 
+BayesIntervalCalc::UpperBound(PDF &b_prob_, double expectedCounts_, double expectedCountsSigma_, int observedCounts_, double cl_){
+    // Choose some signal points. Try using 25 equally spaced points between 0 and expectedCounts_ (rounded to int)
+    int n_sig_points = 25;
+    std::vector<double> signals;
+    for(int i=0; i<n_sig_points; i++) signals.push_back(double(i*int(expectedCounts_+0.5)/n_sig_points));
+    
+    AxisCollection axes;
+    axes.AddAxis(BinAxis("sig",0,int(expectedCounts_+0.5),n_sig_points,"sig"));
+    Histogram mlhs_hist(axes);
+    
+    std::vector<double> mlhs;
+    double sum = 0.0;
+    int critBin=0;
+    for(size_t i=0; i<signals.size()-1; i++){    
+        if(sum > 0.99) sum = 1.0;
+        else sum += BayesIntervalCalc::CumulativePosterior(b_prob_, signals[i], signals[i+1], expectedCounts_, expectedCountsSigma_, observedCounts_);
+        mlhs.push_back(sum);
+        if(sum < cl_) critBin++;
+    }
+    //Fill histogram object with cumulative posterior values to be interpolated for signal at CL=cl_
+    for(int i=0; i<mlhs.size(); i++) {
+        mlhs_hist.Fill(i, mlhs[i]);
+    }
+    
+    // now interpolate between the bins    
+    double upperEdge = mlhs_hist.GetAxes().GetBinHighEdge(critBin, 0);
+    double lowerEdge = mlhs_hist.GetAxes().GetBinLowEdge(critBin, 0);
+    double content   = mlhs_hist.GetBinContent(critBin);
+
+    return upperEdge - (upperEdge - lowerEdge) * (sum - cl_)/content;
+}
+
+double BayesIntervalCalc::Marginalise(PDF& b_prob_, double s, double b, double width, int n){
+   //If width is 0, no need to marginalise
+   if(width == 0){
+       return BayesIntervalCalc::PoissonProb(b_prob_,s,b,width,n);   
+   } else {
+       //Integrate over b with fixed s
+       //Fix bkg integral to run between 0 and 1000 in 1000 steps for now
+       int n_bkg_points = 1000;
+       std::vector<double> bkgs;
+       for(size_t i=0; i<n_bkg_points; i++) bkgs.push_back(double(i*1000/n_bkg_points));
+       TH1D bkg_integral = TH1D("bkg","bkg",n_bkg_points, 0, 1000);
+       for(size_t i=0; i<n_bkg_points; i++){
+            bkg_integral.SetBinContent(i+1, BayesIntervalCalc::PoissonProb(b_prob_,s,bkgs[i],width,n));
+       }
+       return bkg_integral.Integral("width");
+   }
+}
+
+double BayesIntervalCalc::CumulativePosterior(PDF& b_prob_, double signal1, double signal2, double expectedCounts_, double expectedCountsSigma_, int observedCounts_){
+    // Fix signal integral to run between signal1 and signal2 in 10000 steps for now
+    int n_sig_points = 10000;
+    std::vector<double> sigs;
+    for(size_t i=0; i<n_sig_points; i++) sigs.push_back(signal1 + double(i*(signal2-signal1)/n_sig_points));
+    // Need to compute the total normalisation as well 
+    // Compute normalisation by integrating signal from 0 to 1000(inf) in 10000 steps for now
+    int n_norm_sig_points = 10000;
+    std::vector<double> norm_sigs;
+    for(size_t i=0; i<n_norm_sig_points; i++) norm_sigs.push_back(double(i*(1000.0)/n_sig_points));
+    
+    TH1D sig_integral = TH1D("sig","sig",n_sig_points, signal1, signal2);
+    TH1D norm_sig_integral = TH1D("norm_sig","norm_sig",n_norm_sig_points, 0, 1000);
+
+    for(size_t i=0; i<n_norm_sig_points; i++) norm_sig_integral.SetBinContent(i+1, BayesIntervalCalc::Marginalise(b_prob_,norm_sigs[i],expectedCounts_,expectedCountsSigma_,observedCounts_));
+    double norm = norm_sig_integral.Integral("width");
+    
+    //Integrate s from signal1 to signal2
+    for(size_t i=0; i<n_sig_points; i++) {
+        double result = BayesIntervalCalc::Marginalise(b_prob_,sigs[i],expectedCounts_,expectedCountsSigma_,observedCounts_)/norm;
+        sig_integral.SetBinContent(i+1, result );
+    }
+     
+    return sig_integral.Integral("width");    
+    
+}
+
+double BayesIntervalCalc::PoissonProb(PDF& b_prob_, double s, double b, double width, int n) {
+   double computed_value = 1.0;
+   //Apply a Poisson probability (s+b)^n / n! * exp(-(s+b)) and whatever background distribution is stored in b_prob
+   if(width == 0){
+        computed_value *= std::pow(s + b, n);
+        computed_value *= 1.0/(gsl_sf_fact(n));
+        computed_value *= exp(-1*(s + b));
+   } else {
+        std::vector<double> values_b_prob;
+        values_b_prob.push_back(b);
+       
+        computed_value *= b_prob_( values_b_prob);
+        computed_value *= std::pow(s + b, n);
+        computed_value *= 1.0/(gsl_sf_fact(n));
+        computed_value *= exp(-1*(s + b));
+   }
+   return computed_value;
 }

--- a/src/interval/BayesIntervalCalc.cpp
+++ b/src/interval/BayesIntervalCalc.cpp
@@ -2,6 +2,7 @@
 #include <Exceptions.h>
 #include <Histogram.h>
 #include <TH1D.h>
+#include <TGraph.h>
 #include <gsl/gsl_sf_gamma.h> // imcomplete gamma function
 #include <iostream>
 #include <cmath>
@@ -64,35 +65,33 @@ BayesIntervalCalc::UpperBound(double expectedCounts_, int observedCounts_, doubl
 
 double 
 BayesIntervalCalc::UpperBound(PDF &b_prob_, double expectedCounts_, double expectedCountsSigma_, int observedCounts_, double cl_){
-    // Choose some signal points. Try using 25 equally spaced points between 0 and expectedCounts_ (rounded to int)
-    int n_sig_points = 25;
+    // Choose some signal points to test. Try using 50 equally spaced points between 0 and 2*expectedCounts_ (rounded to int)
+    int n_sig_points = 50;
     std::vector<double> signals;
-    for(int i=0; i<n_sig_points; i++) signals.push_back(double(i*int(expectedCounts_+0.5)/n_sig_points));
-    
-    AxisCollection axes;
-    axes.AddAxis(BinAxis("sig",0,int(expectedCounts_+0.5),n_sig_points,"sig"));
-    Histogram mlhs_hist(axes);
+    for(size_t i=0; i<n_sig_points; i++) {
+        signals.push_back(double(2*i*int(expectedCounts_+0.5)/n_sig_points));
+    }
     
     std::vector<double> mlhs;
+    mlhs.push_back(0.0);
     double sum = 0.0;
-    int critBin=0;
-    for(size_t i=0; i<signals.size()-1; i++){    
+    for(size_t i=1; i<signals.size(); i++) {    
         if(sum > 0.99) sum = 1.0;
-        else sum += BayesIntervalCalc::CumulativePosterior(b_prob_, signals[i], signals[i+1], expectedCounts_, expectedCountsSigma_, observedCounts_);
+        else sum += BayesIntervalCalc::CumulativePosterior(b_prob_, signals[i-1], signals[i], expectedCounts_, expectedCountsSigma_, observedCounts_);
         mlhs.push_back(sum);
-        if(sum < cl_) critBin++;
-    }
-    //Fill histogram object with cumulative posterior values to be interpolated for signal at CL=cl_
-    for(int i=0; i<mlhs.size(); i++) {
-        mlhs_hist.Fill(i, mlhs[i]);
     }
     
-    // now interpolate between the bins    
-    double upperEdge = mlhs_hist.GetAxes().GetBinHighEdge(critBin, 0);
-    double lowerEdge = mlhs_hist.GetAxes().GetBinLowEdge(critBin, 0);
-    double content   = mlhs_hist.GetBinContent(critBin);
-
-    return upperEdge - (upperEdge - lowerEdge) * (sum - cl_)/content;
+    //Fill TGraph object with cumulative posterior values to be interpolated for signal at CL=cl_
+    TGraph graph = TGraph(n_sig_points,&mlhs[0],&signals[0]);
+    
+    for(size_t i=0; i<mlhs.size(); i++) {
+        double x=0.0;
+        double y=0.0;
+        graph.GetPoint(i,x,y);
+        std::cout << "i: " << i <<  ", x: " << x << ", y: " << y << std::endl;
+    }
+    //Performs a linear interpolation
+    return graph.Eval(cl_);
 }
 
 double BayesIntervalCalc::Marginalise(PDF& b_prob_, double s, double b, double width, int n){
@@ -101,38 +100,33 @@ double BayesIntervalCalc::Marginalise(PDF& b_prob_, double s, double b, double w
        return BayesIntervalCalc::PoissonProb(b_prob_,s,b,width,n);   
    } else {
        //Integrate over b with fixed s
-       //Fix bkg integral to run between 0 and 1000 in 1000 steps for now
+       //Fix bkg integral to run between 0 and 1000 in 1000 steps 
        int n_bkg_points = 1000;
-       std::vector<double> bkgs;
-       for(size_t i=0; i<n_bkg_points; i++) bkgs.push_back(double(i*1000/n_bkg_points));
        TH1D bkg_integral = TH1D("bkg","bkg",n_bkg_points, 0, 1000);
        for(size_t i=0; i<n_bkg_points; i++){
-            bkg_integral.SetBinContent(i+1, BayesIntervalCalc::PoissonProb(b_prob_,s,bkgs[i],width,n));
+            bkg_integral.SetBinContent(i+1, BayesIntervalCalc::PoissonProb(b_prob_,s,bkg_integral.GetBinCenter(i+1),width,n));
        }
        return bkg_integral.Integral("width");
    }
 }
 
-double BayesIntervalCalc::CumulativePosterior(PDF& b_prob_, double signal1, double signal2, double expectedCounts_, double expectedCountsSigma_, int observedCounts_){
+double BayesIntervalCalc::CumulativePosterior(PDF& b_prob, double signal1, double signal2, double b, double width, int n){
     // Fix signal integral to run between signal1 and signal2 in 10000 steps for now
     int n_sig_points = 10000;
-    std::vector<double> sigs;
-    for(size_t i=0; i<n_sig_points; i++) sigs.push_back(signal1 + double(i*(signal2-signal1)/n_sig_points));
     // Need to compute the total normalisation as well 
     // Compute normalisation by integrating signal from 0 to 1000(inf) in 10000 steps for now
     int n_norm_sig_points = 10000;
-    std::vector<double> norm_sigs;
-    for(size_t i=0; i<n_norm_sig_points; i++) norm_sigs.push_back(double(i*(1000.0)/n_sig_points));
     
     TH1D sig_integral = TH1D("sig","sig",n_sig_points, signal1, signal2);
     TH1D norm_sig_integral = TH1D("norm_sig","norm_sig",n_norm_sig_points, 0, 1000);
 
-    for(size_t i=0; i<n_norm_sig_points; i++) norm_sig_integral.SetBinContent(i+1, BayesIntervalCalc::Marginalise(b_prob_,norm_sigs[i],expectedCounts_,expectedCountsSigma_,observedCounts_));
+    for(size_t i=0; i<n_norm_sig_points; i++) norm_sig_integral.SetBinContent(i+1, BayesIntervalCalc::Marginalise(b_prob,norm_sig_integral.GetBinCenter(i+1),b,width,n));
     double norm = norm_sig_integral.Integral("width");
     
     //Integrate s from signal1 to signal2
     for(size_t i=0; i<n_sig_points; i++) {
-        double result = BayesIntervalCalc::Marginalise(b_prob_,sigs[i],expectedCounts_,expectedCountsSigma_,observedCounts_)/norm;
+        double result = BayesIntervalCalc::Marginalise(b_prob,sig_integral.GetBinCenter(i+1),b,width,n);
+        result = result/norm;
         sig_integral.SetBinContent(i+1, result );
     }
      
@@ -140,7 +134,7 @@ double BayesIntervalCalc::CumulativePosterior(PDF& b_prob_, double signal1, doub
     
 }
 
-double BayesIntervalCalc::PoissonProb(PDF& b_prob_, double s, double b, double width, int n) {
+double BayesIntervalCalc::PoissonProb(PDF& b_prob, double s, double b, double width, int n) {
    double computed_value = 1.0;
    //Apply a Poisson probability (s+b)^n / n! * exp(-(s+b)) and whatever background distribution is stored in b_prob
    if(width == 0){
@@ -151,7 +145,7 @@ double BayesIntervalCalc::PoissonProb(PDF& b_prob_, double s, double b, double w
         std::vector<double> values_b_prob;
         values_b_prob.push_back(b);
        
-        computed_value *= b_prob_( values_b_prob);
+        computed_value *= b_prob(values_b_prob);
         computed_value *= std::pow(s + b, n);
         computed_value *= 1.0/(gsl_sf_fact(n));
         computed_value *= exp(-1*(s + b));

--- a/src/interval/BayesIntervalCalc.h
+++ b/src/interval/BayesIntervalCalc.h
@@ -1,11 +1,16 @@
 #ifndef __OXSX_BAYESINTERVALCALC__
 #define __OXSX_BAYESINTERVALCALC__
 #include <Histogram.h>
+#include <PDF.h>
 
 class BayesIntervalCalc{
  public:
     static double UpperBound(Histogram lh_, double cl_); // needs to be a 1D histogram
     static double UpperBound(double expectedCounts_, int observedCounts_, double cl_, double tolerance_, double startValue_ = 0);
+    static double UpperBound(PDF& b_prob_, double expectedCounts_, double expectedCountsSigma_, int observedCounts_, double cl_);
+    static double Marginalise(PDF& b_prob_, double s, double b, double width, int n);
+    static double CumulativePosterior(PDF& b_prob_, double signal1, double signal2, double expectedCounts_, double expectedCountsSigma_, int observedCounts_);
+    static double PoissonProb(PDF& b_prob_, double s, double b, double width, int n);
     static double OneSidedUpperInterval(double expectedCounts_, int observedCounts_, double upperEdge_);
 };
 #endif

--- a/src/interval/BayesIntervalCalc.h
+++ b/src/interval/BayesIntervalCalc.h
@@ -8,9 +8,10 @@ class BayesIntervalCalc{
     static double UpperBound(Histogram lh_, double cl_); // needs to be a 1D histogram
     static double UpperBound(double expectedCounts_, int observedCounts_, double cl_, double tolerance_, double startValue_ = 0);
     static double UpperBound(PDF& b_prob_, double expectedCounts_, double expectedCountsSigma_, int observedCounts_, double cl_);
-    static double Marginalise(PDF& b_prob_, double s, double b, double width, int n);
-    static double CumulativePosterior(PDF& b_prob_, double signal1, double signal2, double expectedCounts_, double expectedCountsSigma_, int observedCounts_);
-    static double PoissonProb(PDF& b_prob_, double s, double b, double width, int n);
     static double OneSidedUpperInterval(double expectedCounts_, int observedCounts_, double upperEdge_);
+ private:   
+    static double Marginalise(PDF& b_prob, double s, double b, double width, int n);
+    static double CumulativePosterior(PDF& b_prob, double signal1, double signal2, double b, double width, int n);
+    static double PoissonProb(PDF& b_prob, double s, double b, double width, int n);
 };
 #endif


### PR DESCRIPTION
I finished my first attempt at this before I left for holiday but obviously forgot to make the PR. After much faffing to try to find the best way to do this I went with this implementation. It allows for a generic PDF object which contains the distribution of total background, then uses the () operator to pull out the probability for a given background value, which then directly feeds into the integral (either over s for fixed b or over b and s depending on whether the width is non zero). I did some playing around with the number of bins for the integral using a gaussian PDF as input with various widths and I managed to reproduce the values from the python code (where the integration is handled by scipy.integrate.quad) to a few significant figures so I think it is ok (and adding more bins to the integration doesn't seem to make much difference). Unfortunately the number of bins is hardcoded, as is the range of the integrals, so maybe this isn't ideal, but I haven't come up with a better way to do it. Comments welcome, I'm not completely happy with it so you may have some ideas how to improve it. 