### PR TITLE
Prior and PriorManager class.

### DIFF
--- a/examples/PriorExample.cpp
+++ b/examples/PriorExample.cpp
@@ -1,0 +1,270 @@
+/* Example shows how to create Prior objects which can be used to constrain
+ * floated variable by applying a penalty term to the fitting function. The
+ * magnitude of the penalty term is given by a class inheriting from the
+ * Function class (interface).
+ *
+ * A Prior can depend solely on the primary variable as well as other terms
+ * known the ComponentManager. Dependences can be added to the Prior with the
+ * SetDependents member function.
+ *
+ * Once a Prior is set up it may be added to a fitting function by calling the
+ * AddPrior() function on said fitting function.
+ *
+ */
+
+#include <iostream>
+#include <iomanip>
+#include <Prior.h>
+#include <Function.h>
+#include <PriorManager.h>
+#include <Gaussian.h>
+#include <ParameterDict.h>
+#include <math.h>
+#include <TRandom3.h>
+class Func: public Function
+{
+  public:
+    Func(int num):Function(), fNdims(num){;}
+    double operator() (const std::vector<double>& params) const{
+      double exponent = 0;
+      double mean;
+      double stdDev =1;
+      double nDevs;
+
+      double diff = params[0];
+      for (int i = 1; i < fNdims; ++i) {
+        diff -= params[i];
+      }
+      nDevs = (diff)/stdDev;
+      exponent += nDevs * nDevs;
+
+      double norm = 1;
+      norm *= sqrt(2*M_PI)*stdDev;
+
+      return exp(- 0.5* exponent) / norm; 
+    }
+    void SetParameter(const std::string&, double){;}
+    double GetParameter(const std::string&) const{;}
+    void SetParameters(const ParameterDict&){;}
+    ParameterDict GetParameters() const{;}
+    size_t GetParameterCount() const{;}
+    void RenameParameter(const std::string&, const std::string&){;}
+    std::string GetName() const{;}
+    void SetName(const std::string&){;}
+    Function* Clone() const{
+      return static_cast<Function*> (new Func(fNdims));
+    }
+    int GetNDims() const{;}
+    std::set<std::string> GetParameterNames() const{;}
+
+  private:
+    int fNdims;
+};
+
+void GaussianPrior(ParameterDict dict);
+void PriorWithDependence(ParameterDict dict);
+void PriorWith2Dependence(ParameterDict dict);
+
+int main(int argc, char *argv[])
+{
+  std::cout << "Starting prior example" << std::endl; 
+
+  ParameterDict dict;
+  dict["alpha"]  =10;
+  dict["beta"]   =2;
+  dict["gamma"]  =4;
+  dict["delta"]  =5;
+  dict["epsilon"]=9;
+
+  GaussianPrior(dict);
+  PriorWithDependence(dict);
+  PriorWith2Dependence(dict);
+
+  return 0;
+}
+
+void GaussianPrior(ParameterDict dict){
+  // Setting a prior on a single floating parameter.
+  Prior* pir = new Prior();
+  // Set the function used to constrain the parameter. 
+  // pir->SetFunction(new Gaussian(4,0.3));
+  pir->SetFunction(new Gaussian(4,3));
+  // Set the primary variable of by name. 
+  pir->SetPrimary("alpha");
+
+  // Then you're done.
+  // To add to a fitting function e.g. BinnedNLLH. Use
+  // the AddPrior function. e.g. lh.AddPrior(&pir); 
+
+  {
+    // This is a simple optimisation loop. Just to give some kind of output
+    // showing that the parameter "alpha" changes according to the output of
+    // the probability method which uses the underline function to put a numerical value on the difference between the current values and the required value.   
+
+    double perviousProb = 0;
+    bool Qup =false;
+    TRandom3 rand;
+
+    std::cout << "\nGaussian is centred about 4" << std::endl; 
+    std::cout<<"Starting dummy optimisation"<<std::endl;
+    for (int i = 0; i < 15; ++i) {
+      if(i==0){
+        double randd= rand.Integer(1);
+        dict["beta"] = dict["beta"]+pow(1,randd);
+        if(randd<0)
+          Qup = false;
+        else
+          Qup = true;
+      }
+      double prob =pir->Probability(dict); 
+      std::cout<<"alpha = "<<std::setprecision(3)<< dict["alpha"]<< std::fixed 
+        << std::setw(8)<<std::setprecision(6)
+        << " prob = "<< prob << std::setprecision(3)
+        <<"\t => Term added to a BinnedNLLH = "<<-log(prob)<<std::endl;
+      if(prob < perviousProb){
+        if(Qup == true){
+          dict["alpha"]  =dict["alpha"]-1;
+          Qup= false;
+        }else{
+          dict["alpha"]  =dict["alpha"]+1;
+          Qup= true;
+        }
+
+      }else{
+        if(Qup == true){
+          dict["alpha"]  =dict["alpha"]+1;
+        }else{
+          dict["alpha"]  =dict["alpha"]-1;
+        }
+      }
+      perviousProb = prob;
+    }
+  }
+}
+
+void PriorWithDependence(ParameterDict dict){
+  // For priors that depend on a single other floated parameters.
+
+  // The function relating the primary variable value to its dependences can be
+  // any user defined function that inherits from Function. 
+  //
+  // The vector that the function acts on must be of the form {fPrimary,dep} 
+  //
+  // (fyi Func is a gaussian constraint centred on the dependent variable.)
+  Func* func= new Func(2);
+  Prior* pir = new Prior();
+  pir->SetFunction(func);
+  // Set the primary variable of by name. 
+  pir->SetPrimary("alpha");
+  // Set the dependent variable by passing the parameter name. It
+  // is important that the order matches that of the dependants in the function
+  // definition.
+
+  pir->SetDependent("beta");
+
+  //Now everything is setup
+  //To add to a fitting function e.g. BinnedNLLH. Use
+  //the AddPrior function. e.g. lh.AddPrior(&pir); 
+
+  {
+    // This is a simple optimisation loop. Just to give some kind of output
+    // showing that changing the ParameterDict passed to the probability
+    // method returns 
+
+    double perviousProb = 0;
+    bool Qup =false;
+    TRandom3 rand;
+
+    std::cout<<"\nStarting single dependent dummy optimisation"<<std::endl;
+    for (int i = 0; i < 15; ++i) {
+      if(i==0){
+        double randd= rand.Integer(1);
+        dict["beta"] = dict["beta"]+pow(1,randd);
+        if(randd<0)
+          Qup = false;
+        else
+          Qup = true;
+      }
+      double prob =pir->Probability(dict); 
+      std::cout<<"alpha = "<<std::setprecision(3)<< dict["alpha"]<< std::fixed 
+        << std::setw(10)<< " beta = "<< dict["beta"] <<std::setprecision(6)
+        << " prob = "<< prob << std::setprecision(3)
+        <<"\t => Term added to a BinnedNLLH = "<< -log(prob)<<std::endl;
+      if(prob < perviousProb){
+        if(Qup == true){
+          dict["alpha"]  =dict["alpha"]-1;
+          Qup= false;
+        }else{
+          dict["alpha"]  =dict["alpha"]+1;
+          Qup= true;
+        }
+
+      }else{
+        if(Qup == true){
+          dict["alpha"]  =dict["alpha"]+1;
+        }else{
+          dict["alpha"]  =dict["alpha"]-1;
+        }
+      }
+      perviousProb = prob;
+    }
+  }
+}
+
+void PriorWith2Dependence(ParameterDict dict){
+  // The function relating the primary variable value to its dependences can be
+  // any user defined function that inherits from Function. 
+  //
+  // The vector that the function acts on must be of the form {fPrimary,dep_1,dep_2,...} 
+  //
+  // (FYI Func is a gaussian constraint centred on the sum dependent variables. )
+  Func* func= new Func(3);
+  // Set the dependent variable by passing a vector of parameter names. It
+  // is important that the order matches that of the dependants in the function
+  // definition.
+  std::vector<std::string> deps;
+  deps.push_back("gamma");
+  deps.push_back("delta");
+
+  // beta being the primary variable.
+  Prior* pir2 = new Prior("beta",deps,func);
+
+  {
+    double perviousProb = 0;
+    bool Qup =false;
+    TRandom3 rand;
+    std::cout<<"\nStarting double dependences dummy optimisation"<<std::endl;
+    for (int i = 0; i < 15; ++i) {
+      if(i==0){
+        double randd= rand.Integer(1);
+        dict["beta"] = dict["beta"]+pow(1,randd);
+        if(randd<0)
+          Qup = false;
+        else
+          Qup = true;
+      }
+      double prob =pir2->Probability(dict); 
+      std::cout<<"beta = "<<std::setprecision(3)<< dict["beta"]<< std::fixed 
+        << std::setw(10)<< " gamma + delta = "<< dict["gamma"] + dict["delta"] << std::setprecision(6)
+        << " prob = "<< prob << std::setprecision(3)
+        <<"\t => Term added to a BinnedNLLH = "<< -log(prob)<<std::endl;
+      if(prob < perviousProb){
+        if(Qup == true){
+          dict["beta"]  =dict["beta"]-1;
+          Qup= false;
+        }else{
+          dict["beta"]  =dict["beta"]+1;
+          Qup= true;
+        }
+
+      }else{
+        if(Qup == true){
+          dict["beta"]  =dict["beta"]+1;
+        }else{
+          dict["beta"]  =dict["beta"]-1;
+        }
+      }
+      perviousProb = prob;
+    }
+  }
+}

--- a/src/teststat/BinnedNLLH.cpp
+++ b/src/teststat/BinnedNLLH.cpp
@@ -48,7 +48,15 @@ BinnedNLLH::Evaluate(){
         it != fConstraints.end(); ++it)
         nLogLH += it->second.Evaluate(fComponentManager.GetParameter(it->first));
 
+    // The logged probabilty will be negative, therefore we take it away from the nLogLH.
+    nLogLH -= fPriorManager.GetLogProbabilities(fComponentManager.GetParameters());
+
     return nLogLH;
+}
+
+void
+BinnedNLLH::AddPrior(const Prior& pir_){
+  fPriorManager.AddPrior(pir_);
 }
 
 void

--- a/src/teststat/BinnedNLLH.h
+++ b/src/teststat/BinnedNLLH.h
@@ -9,6 +9,8 @@
 #include <CutCollection.h>
 #include <CutLog.h>
 #include <QuadraticConstraint.h>
+#include <Prior.h>
+#include <PriorManager.h>
 #include <map>
 #include <vector>
 
@@ -27,6 +29,7 @@ class BinnedNLLH : public TestStatistic{
     void   AddSystematics(const std::vector<Systematic*>);
 
     void   SetConstraint(const std::string& paramName_, double mean_, double sigma_);
+    void   AddPrior(const Prior&);
     
     void SetNormalisations(const std::vector<double>& norms_);
     std::vector<double> GetNormalisations() const;
@@ -65,6 +68,7 @@ class BinnedNLLH : public TestStatistic{
     BinnedEDManager      fPdfManager;
     SystematicManager    fSystematicManager;
     BinnedEDShrinker     fPdfShrinker;
+    PriorManager         fPriorManager;
     DataSet*             fDataSet;
     CutCollection        fCuts;
     std::map<std::string, QuadraticConstraint> fConstraints;

--- a/src/teststat/Prior.cpp
+++ b/src/teststat/Prior.cpp
@@ -1,0 +1,72 @@
+#include <Prior.h>
+#include <iostream>
+#include <Exceptions.h>
+#include <algorithm>
+#include <ContainerTools.hpp>
+
+using ContainerTools::ToString;
+using ContainerTools::GetKeys;
+
+Prior::Prior(const Prior& other_){
+    //What do you need to copy over?
+    fPrimary= other_.fPrimary;
+    fDependence= other_.fDependence;
+    function = dynamic_cast<Function*>(other_.function->Clone());
+}
+
+Prior& Prior::operator=(const Prior& other_)
+{
+    fPrimary= other_.fPrimary;
+    fDependence= other_.fDependence;
+    function = dynamic_cast<Function*>(other_.function->Clone());
+    return *this;
+}
+
+Prior::~Prior(){
+    delete function;
+}
+
+void
+Prior::SetPrimary(const std::string& pri_){
+  fPrimary = pri_;
+}
+
+void
+Prior::SetDependent(const std::string& dep_){
+  std::vector<std::string> dep;
+  dep.push_back(dep_);
+  fDependence = dep;
+}
+
+void
+Prior::SetDependents(std::vector<std::string>& deps_){
+  fDependence = deps_;
+}
+
+void
+Prior::SetFunction(Function* func){
+    function=func;
+}
+
+Function*
+Prior::GetFunction(){
+    return function;
+}
+
+double
+Prior::Probability(const ParameterDict& param_){
+    std::vector<double> parameters;
+    if( param_.find(fPrimary) == param_.end())
+        throw ParameterError(Formatter()<<"Prior:: The primary variable \'"<<fPrimary<<"\' isn't in the testStat. TestStat has: [ "<<ToString(GetKeys(param_))<<"]");
+    parameters.push_back(param_.at(fPrimary));
+
+    for (std::vector<std::string>::const_iterator para_ = fDependence.begin(); para_ != fDependence.end(); ++para_) {
+        if( param_.find(*para_) == param_.end())
+            throw ParameterError(Formatter()<<"Prior:: The dependence  \'"<<*para_<< "\' isn't in the testStat. TestStat has: [ "<<ToString(GetKeys(param_))<<"]");
+        parameters.push_back(param_.at(*para_));
+    }
+    if(!function)
+        throw LogicError(Formatter()<<"Prior:: function not set.");
+
+    return function->operator()(parameters);
+}

--- a/src/teststat/Prior.h
+++ b/src/teststat/Prior.h
@@ -1,0 +1,41 @@
+#ifndef __OXSX_PIROR__
+#define __OXSX_PIROR__
+#include <vector>
+#include <string>
+#include <stddef.h>
+#include <Function.h>
+#include <Gaussian.h>
+#include <ParameterDict.h>
+
+
+class Prior{
+    public:
+        Prior(){;}
+        ~Prior();
+        Prior(const Prior&);
+        Prior& operator=(const Prior&);
+        Prior(const std::string& pri_, Function* func):
+            fPrimary(pri_), function(func){;}
+        Prior(const std::string& pri_,std::vector<std::string>& deps_ , Function* func):
+            fPrimary(pri_), fDependence(deps_), function(func){;}
+        Prior(const std::string& pri_,std::string& dep_ , Function* func):
+            fPrimary(pri_), fDependence( std::vector<std::string>(1,dep_) ), function(func){;}
+
+
+        void SetPrimary(const std::string&);
+        std::string GetPrimary()const{return fPrimary;}
+        void SetDependent(const std::string&);
+        void SetDependents(std::vector<std::string>&);
+        std::vector<std::string> GetDependents(){return fDependence;}
+        void SetFunction(Function* func);
+        Function* GetFunction();
+
+        double Probability(const ParameterDict&);
+
+    private:
+        std::string fPrimary;
+        std::vector<std::string> fDependence;
+        Function* function;
+};
+#endif
+

--- a/src/teststat/PriorManager.cpp
+++ b/src/teststat/PriorManager.cpp
@@ -1,0 +1,54 @@
+#include <Prior.h>
+#include <math.h>
+#include <PriorManager.h>
+#include <iostream>
+#include <Exceptions.h>
+
+PriorManager::PriorManager(const PriorManager& other_ ){
+  priorList =  other_.priorList;
+}
+
+PriorManager& PriorManager::operator=(const PriorManager& other_)
+{
+  priorList =  other_.priorList;
+  return *this;
+}
+
+int
+PriorManager::GetNPriors(){
+  return priorList.size();
+}
+void
+PriorManager::AddPrior(const Prior& prior){
+  std::string pri = prior.GetPrimary();
+  for (std::vector<Prior>::iterator i = priorList.begin(); i != priorList.end(); ++i) {
+    if (i->GetPrimary()== pri)
+      throw LogicError(Formatter()<<"PriorManager:: Two prior  priors with the same primary variable");
+  }
+  priorList.push_back(prior);
+}
+
+std::vector<Prior>
+PriorManager::GetPriors(){
+  return priorList;
+}
+
+double PriorManager::GetProbabilities( const ParameterDict& params_){
+  double result=0;
+  for (std::vector<Prior>::iterator iter = priorList.begin(); iter != priorList.end(); ++iter ) {
+    result += (*iter).Probability(params_);
+  }
+  return result;
+
+}
+
+
+double PriorManager::GetLogProbabilities( const ParameterDict& params_){
+  double result=0;
+  for (std::vector<Prior>::iterator iter = priorList.begin(); iter != priorList.end(); ++iter ) {
+    if((*iter).Probability(params_)<=0)
+      throw ParameterError(Formatter()<<"PriorManager:: Attempting to log a negative value.");
+    result += log((*iter).Probability(params_));
+  }
+  return result;
+}

--- a/src/teststat/PriorManager.h
+++ b/src/teststat/PriorManager.h
@@ -1,0 +1,31 @@
+#ifndef __OXSX_PRIOR_MANAGER__
+#define __OXSX_PRIOR_MANAGER__
+#include <vector>
+#include <map>
+#include <string>
+#include <stddef.h>
+#include <Function.h>
+#include <Prior.h>
+#include <ParameterDict.h>
+
+class PriorManager{
+    public:
+        PriorManager(){;}
+        PriorManager& operator=(const PriorManager& other_);
+        PriorManager(const PriorManager&);
+
+        PriorManager(std::vector<Prior>& initList){
+            priorList=initList;
+        }
+
+        void AddPrior(const Prior& prior);
+        std::vector<Prior> GetPriors();
+        int GetNPriors();
+        double GetProbabilities( const ParameterDict& params_);
+        double GetLogProbabilities( const ParameterDict& params_);
+
+    private:
+        std::vector<Prior> priorList;
+};
+#endif
+

--- a/test/unit/PriorManagerTest.cpp
+++ b/test/unit/PriorManagerTest.cpp
@@ -1,0 +1,92 @@
+#include <catch.hpp>
+#include <iostream>
+#include <PriorManager.h>
+#include <Prior.h>
+#include <ParameterDict.h>
+#include <Function.h>
+
+// Test function 
+class Func: public Function
+{
+    public:
+        Func(int num):Function(),  fNDims(num){;}
+        double operator() (const std::vector<double>& params) const{
+            double ans = params[0];
+            for (int i = 1; i < params.size(); ++i) {
+              ans -= params[i];
+            }
+            return ans;
+        }
+        void SetParameter(const std::string&, double){;}
+        double GetParameter(const std::string&) const{;}
+        void SetParameters(const ParameterDict&){;}
+        ParameterDict GetParameters() const{;}
+        size_t GetParameterCount() const{;}
+        void RenameParameter(const std::string&, const std::string&){;}
+        std::string GetName() const{;}
+        void SetName(const std::string&){;}
+        Function* Clone() const{
+          return static_cast<Function*> (new Func(fNDims));
+        }
+        int GetNDims() const{;}
+        std::set<std::string> GetParameterNames() const{;}
+
+
+    private:
+        int fNDims;
+};
+
+TEST_CASE("PRIORMANAGER TEST"){
+    ParameterDict dict;
+    dict["alpha"]  =10;
+    dict["beta"]   =5;
+    dict["gamma"]  =1;
+    dict["delta"]  =1;
+    dict["epsilon"]=1;
+    Func* func = new Func(2);
+    Func* func_2 = new Func(4);
+
+    Prior* pri = new Prior();
+    pri->SetFunction(func);
+    pri->SetPrimary("alpha");
+    pri->SetDependent("beta");
+    Prior* pri_2 = new Prior();
+    pri_2->SetFunction(func_2);
+    pri_2->SetPrimary("beta");
+
+    std::vector<std::string> deps;
+    deps.push_back("gamma");
+    deps.push_back("delta");
+    deps.push_back("epsilon");
+    pri_2->SetDependents(deps);
+
+    std::vector<Prior> priors;
+    priors.push_back(*pri);
+    priors.push_back(*pri_2);
+    PriorManager * man = new PriorManager(priors);
+    
+    PriorManager * man_2 = new PriorManager();
+    man_2->AddPrior(*pri);
+    man_2->AddPrior(*pri_2);
+
+    SECTION("Prior :: Getters and Setter"){
+        REQUIRE(man->GetNPriors() == 2);
+        REQUIRE(man_2->GetNPriors() == 2);
+    }
+    SECTION("Prior :: Calling Probability"){
+        REQUIRE(man->GetProbabilities(dict) == 7);
+    }
+    SECTION("Prior :: Checking error codes"){
+
+        dict["delta"]=100;
+
+        int flag = 0;
+        try { 
+          man->GetLogProbabilities(dict);
+        }catch(const ParameterError& e_){
+          flag=1;
+        }
+
+        REQUIRE( flag == 1 );
+    }
+}

--- a/test/unit/PriorTest.cpp
+++ b/test/unit/PriorTest.cpp
@@ -1,0 +1,110 @@
+#include <catch.hpp>
+#include <iostream>
+#include <Prior.h>
+#include <ParameterDict.h>
+#include <Function.h>
+
+// Test function 
+class Func: public Function
+{
+    public:
+        Func(int num):Function(),  fNDims(num){;}
+        double operator() (const std::vector<double>& params) const{
+            double ans = params[0];
+            for (int i = 1; i < params.size(); ++i) {
+              ans -= params[i];
+            }
+            return ans;
+        }
+        void SetParameter(const std::string&, double){;}
+        double GetParameter(const std::string&) const{;}
+        void SetParameters(const ParameterDict&){;}
+        ParameterDict GetParameters() const{;}
+        size_t GetParameterCount() const{;}
+        void RenameParameter(const std::string&, const std::string&){;}
+        std::string GetName() const{;}
+        void SetName(const std::string&){;}
+        Function* Clone() const{
+          return static_cast<Function*> (new Func(fNDims));
+        }
+        int GetNDims() const{;}
+        std::set<std::string> GetParameterNames() const{;}
+
+
+    private:
+        int fNDims;
+};
+
+TEST_CASE("PIROR TEST"){
+    ParameterDict dict;
+    dict["alpha"]  =10;
+    dict["beta"]   =1;
+    dict["gamma"]  =1;
+    dict["delta"]  =1;
+    dict["epsilon"]=1;
+    Func* func = new Func(2);
+    Func* func_2 = new Func(4);
+
+    Prior* pir = new Prior();
+   
+    SECTION("Prior :: Getters and Setter"){
+        pir->SetPrimary("alpha");
+        REQUIRE(pir->GetPrimary() == "alpha");
+        pir->SetDependent("beta");
+
+        REQUIRE(pir->GetDependents().size() == 1);
+        REQUIRE(pir->GetDependents()[0] == "beta");
+        std::vector<std::string> deps;
+        deps.push_back("beta");
+        deps.push_back("gamma");
+        deps.push_back("delta");
+        deps.push_back("epsilon");
+        pir->SetDependents(deps);
+        REQUIRE(pir->GetDependents()[3] == "epsilon");
+    }
+    SECTION("Prior :: Calling Probability"){
+        pir->SetFunction(func);
+        pir->SetPrimary("alpha");
+        // pir->SetPrimary("phi");
+        pir->SetDependent("beta");
+
+        REQUIRE(pir->Probability(dict) == 9);
+        std::vector<std::string> deps;
+        deps.push_back("beta");
+        deps.push_back("gamma");
+        deps.push_back("delta");
+        deps.push_back("epsilon");
+        // deps.push_back("phi");
+        pir->SetDependents(deps);
+        REQUIRE(pir->Probability(dict) == 6);
+    }
+    SECTION("Prior :: Checking error codes"){
+        pir->SetFunction(func_2);
+        pir->SetPrimary("phi");
+
+        int flag = 0;
+        try { 
+          pir->Probability(dict);
+        }catch(const ParameterError& e_){
+          flag=1;
+        }
+ 
+        REQUIRE( flag == 1 );
+
+        std::vector<std::string> deps;
+        deps.push_back("beta");
+        deps.push_back("gamma");
+        deps.push_back("delta");
+        deps.push_back("rho");
+        pir->SetDependents(deps);
+
+        pir->SetPrimary("alpha");
+        try { 
+          pir->Probability(dict);
+        }catch(const ParameterError& e_){
+          flag=2;
+        }
+ 
+        REQUIRE( flag == 2 );
+    }
+}


### PR DESCRIPTION
Added a Prior class that applies a penalty term to a BinnedNLLH depending on how the primary variable compares to the underlining function governing the prior.

Priors can be set with and without dependance on other floating varibles.

The PriorManager class looks after all the applied priors and is used to add the penalty term to the likelihood.

See examples/PriorExample.cpp for example uses.